### PR TITLE
Estimate issue effort with repository context

### DIFF
--- a/api/migrations/20260416193000-ai-prediction-estimated-hours.js
+++ b/api/migrations/20260416193000-ai-prediction-estimated-hours.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260416193000-ai-prediction-estimated-hours-up.sql',
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260416193000-ai-prediction-estimated-hours-down.sql',
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/sqls/20260416193000-ai-prediction-estimated-hours-down.sql
+++ b/api/migrations/sqls/20260416193000-ai-prediction-estimated-hours-down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE system."ai_prediction"
+DROP CONSTRAINT IF EXISTS ai_prediction_estimation_confidence_check;
+
+ALTER TABLE system."ai_prediction"
+DROP COLUMN IF EXISTS estimation_confidence,
+DROP COLUMN IF EXISTS estimated_hours;

--- a/api/migrations/sqls/20260416193000-ai-prediction-estimated-hours-up.sql
+++ b/api/migrations/sqls/20260416193000-ai-prediction-estimated-hours-up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE system."ai_prediction"
+ADD COLUMN IF NOT EXISTS estimated_hours integer,
+ADD COLUMN IF NOT EXISTS estimation_confidence text;
+
+ALTER TABLE system."ai_prediction"
+DROP CONSTRAINT IF EXISTS ai_prediction_estimation_confidence_check;
+
+ALTER TABLE system."ai_prediction"
+ADD CONSTRAINT ai_prediction_estimation_confidence_check
+  CHECK (
+    estimation_confidence IN ('low', 'medium', 'high')
+    OR estimation_confidence IS NULL
+  );

--- a/api/src/__tests__/unit/controllers/issue.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/issue.controller.test.ts
@@ -45,10 +45,14 @@ describe('GithubIssueController (unit)', () => {
       predictIssuePriority: vi.fn().mockResolvedValue({
         priority: 'High',
         reason: 'Blocks the release',
+        estimatedHours: 8,
+        estimationConfidence: 'medium',
       }),
     };
     const repositoryRepository = {
-      findById: vi.fn().mockResolvedValue({workspaceId: 9}),
+      findById: vi
+        .fn()
+        .mockResolvedValue({workspaceId: 9, fullName: 'team/api'}),
     };
     const workspaceRepository = {
       findById: vi.fn().mockResolvedValue({githubInstallationId: 11}),
@@ -72,8 +76,12 @@ describe('GithubIssueController (unit)', () => {
     ).resolves.toEqual({
       priority: 'High',
       reason: 'Blocks the release',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
     });
     expect(priorityService.predictIssuePriority).toHaveBeenCalledWith({
+      installationId: 11,
+      repositoryFullName: 'team/api',
       title: 'Broken sign-in',
       description: 'Users cannot log in',
     });

--- a/api/src/__tests__/unit/models/ai-prediction.model.test.ts
+++ b/api/src/__tests__/unit/models/ai-prediction.model.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest';
 
 import {
+  AI_ESTIMATION_CONFIDENCE_VALUES,
   AIPredictable,
   AIPrediction,
   AI_PREDICTION_SOURCE_TYPES,
@@ -19,6 +20,7 @@ describe('AI prediction models (unit)', () => {
       'issue-priority',
       'pull-request-merge-risk',
     ]);
+    expect(AI_ESTIMATION_CONFIDENCE_VALUES).toEqual(['low', 'medium', 'high']);
   });
 
   it('constructs AI prediction entities with provided values', () => {
@@ -28,6 +30,8 @@ describe('AI prediction models (unit)', () => {
       predictionType: 'issue-priority',
       priority: 'High',
       reason: 'Critical workflow is blocked.',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
     });
 
     expect(model.sourceType).toBe('github-issue');
@@ -35,6 +39,8 @@ describe('AI prediction models (unit)', () => {
     expect(model.predictionType).toBe('issue-priority');
     expect(model.priority).toBe('High');
     expect(model.reason).toBe('Critical workflow is blocked.');
+    expect(model.estimatedHours).toBe(8);
+    expect(model.estimationConfidence).toBe('medium');
   });
 
   it('lets GitHub issue and pull request models inherit from AI predictable', () => {

--- a/api/src/__tests__/unit/services/ai-prediction.service.test.ts
+++ b/api/src/__tests__/unit/services/ai-prediction.service.test.ts
@@ -35,6 +35,8 @@ describe('AIPredictionService (unit)', () => {
       predictionType: 'issue-priority',
       priority: ' High ',
       reason: ' Needs attention ',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
       findings: [],
       reviewerSuggestions: [],
     });
@@ -45,6 +47,8 @@ describe('AIPredictionService (unit)', () => {
       predictionType: 'issue-priority',
       priority: 'High',
       reason: 'Needs attention',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
       findings: [],
       reviewerSuggestions: [],
     });
@@ -59,6 +63,8 @@ describe('AIPredictionService (unit)', () => {
       predictionType: 'pull-request-merge-risk',
       priority: 'Medium',
       reason: 'Touches shared auth flow.',
+      estimatedHours: null,
+      estimationConfidence: null,
       findings: [
         {
           path: 'src/auth.ts',
@@ -78,6 +84,8 @@ describe('AIPredictionService (unit)', () => {
     expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(5, {
       priority: 'Medium',
       reason: 'Touches shared auth flow.',
+      estimatedHours: undefined,
+      estimationConfidence: undefined,
       findings: [
         {
           path: 'src/auth.ts',
@@ -104,6 +112,8 @@ describe('AIPredictionService (unit)', () => {
       predictionType: 'pull-request-merge-risk',
       priority: 'Low',
       reason: 'Latest run found no actionable review findings.',
+      estimatedHours: null,
+      estimationConfidence: null,
       findings: [],
       reviewerSuggestions: [],
     });
@@ -111,6 +121,8 @@ describe('AIPredictionService (unit)', () => {
     expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(6, {
       priority: 'Low',
       reason: 'Latest run found no actionable review findings.',
+      estimatedHours: undefined,
+      estimationConfidence: undefined,
       findings: [],
       reviewerSuggestions: [],
     });
@@ -160,6 +172,8 @@ describe('AIPredictionService (unit)', () => {
         predictionType: 'issue-priority',
         priority: 'High',
         reason: 'Important',
+        estimatedHours: 16,
+        estimationConfidence: 'high',
         reviewerSuggestions: [],
       },
       {
@@ -179,6 +193,8 @@ describe('AIPredictionService (unit)', () => {
         predictionType: 'issue-priority',
         priority: 'High',
         reason: 'Important',
+        estimatedHours: 16,
+        estimationConfidence: 'high',
         findings: undefined,
         reviewerSuggestions: [],
       },
@@ -234,6 +250,8 @@ describe('AIPredictionService (unit)', () => {
       predictionType: 'pull-request-merge-risk',
       priority: ' ',
       reason: '',
+      estimatedHours: null,
+      estimationConfidence: null,
       findings: [],
       reviewerSuggestions: [
         {
@@ -247,6 +265,8 @@ describe('AIPredictionService (unit)', () => {
     expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(12, {
       priority: undefined,
       reason: undefined,
+      estimatedHours: undefined,
+      estimationConfidence: undefined,
       findings: [],
       reviewerSuggestions: [
         {
@@ -255,6 +275,31 @@ describe('AIPredictionService (unit)', () => {
           reason: 'Matches the changed UI area.',
         },
       ],
+    });
+  });
+
+  it('keeps estimate-only predictions because they still have useful content', async () => {
+    aiPredictionRepository.findOne.mockResolvedValue({id: 17});
+
+    await service.syncPrediction({
+      sourceType: 'github-issue',
+      sourceId: 44,
+      predictionType: 'issue-priority',
+      estimatedHours: 6,
+      estimationConfidence: 'low',
+      priority: ' ',
+      reason: '',
+      findings: [],
+      reviewerSuggestions: [],
+    });
+
+    expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(17, {
+      priority: undefined,
+      reason: undefined,
+      estimatedHours: 6,
+      estimationConfidence: 'low',
+      findings: [],
+      reviewerSuggestions: [],
     });
   });
 });

--- a/api/src/__tests__/unit/services/github-webhook.service.test.ts
+++ b/api/src/__tests__/unit/services/github-webhook.service.test.ts
@@ -53,6 +53,8 @@ describe('GithubWebhookService (unit)', () => {
       predictIssuePriority: vi.fn().mockResolvedValue({
         priority: 'High',
         reason: 'The module is unusable.',
+        estimatedHours: 8,
+        estimationConfidence: 'medium',
       }),
     };
     queueService = {
@@ -173,6 +175,8 @@ describe('GithubWebhookService (unit)', () => {
       {
         priority: 'High',
         reason: 'The module is unusable.',
+        estimatedHours: 8,
+        estimationConfidence: 'medium',
       },
     );
     expect(githubService.syncRepositoryLabels).toHaveBeenCalledWith(
@@ -191,6 +195,8 @@ describe('GithubWebhookService (unit)', () => {
       {
         priority: 'High',
         reason: 'The module is unusable.',
+        estimatedHours: 8,
+        estimationConfidence: 'medium',
       },
       'Updated body',
       undefined,

--- a/api/src/__tests__/unit/services/github.service.test.ts
+++ b/api/src/__tests__/unit/services/github.service.test.ts
@@ -345,6 +345,121 @@ describe('GithubService (unit)', () => {
     );
   });
 
+  it('fetches repository overview details for issue estimation context', async () => {
+    const octokit = {
+      request: vi.fn().mockResolvedValue({
+        data: {
+          name: 'api',
+          full_name: 'team/api',
+          description: null,
+          default_branch: 'main',
+          language: 'TypeScript',
+          topics: ['loopback', 'api'],
+          open_issues_count: 3,
+        },
+      }),
+    };
+    vi.spyOn(internals, 'getInstallationClient').mockResolvedValue(
+      octokit as never,
+    );
+
+    await expect(service.getRepositoryOverview(4, 'team/api')).resolves.toEqual(
+      {
+        name: 'api',
+        full_name: 'team/api',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        topics: ['loopback', 'api'],
+        open_issues_count: 3,
+      },
+    );
+
+    expect(octokit.request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}',
+      expect.objectContaining({
+        owner: 'team',
+        repo: 'api',
+      }),
+    );
+  });
+
+  it('lists repository directory entries for issue estimation context', async () => {
+    const octokit = {
+      request: vi.fn().mockResolvedValue({
+        data: [
+          {
+            name: 'package.json',
+            path: 'package.json',
+            type: 'file',
+            size: 200,
+          },
+          {
+            name: 'src',
+            path: 'src',
+            type: 'dir',
+          },
+        ],
+      }),
+    };
+    vi.spyOn(internals, 'getInstallationClient').mockResolvedValue(
+      octokit as never,
+    );
+
+    await expect(
+      service.listRepositoryDirectory(4, 'team/api', 'src'),
+    ).resolves.toEqual([
+      {
+        name: 'package.json',
+        path: 'package.json',
+        type: 'file',
+        size: 200,
+      },
+      {
+        name: 'src',
+        path: 'src',
+        type: 'dir',
+        size: undefined,
+      },
+    ]);
+
+    expect(octokit.request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      expect.objectContaining({
+        owner: 'team',
+        repo: 'api',
+        path: 'src',
+      }),
+    );
+  });
+
+  it('decodes repository file contents for issue estimation context', async () => {
+    const octokit = {
+      request: vi.fn().mockResolvedValue({
+        data: {
+          content: Buffer.from('{"name":"api"}', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      }),
+    };
+    vi.spyOn(internals, 'getInstallationClient').mockResolvedValue(
+      octokit as never,
+    );
+
+    await expect(
+      service.getRepositoryFileContents(4, 'team/api', 'package.json'),
+    ).resolves.toBe('{"name":"api"}');
+
+    expect(octokit.request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      expect.objectContaining({
+        owner: 'team',
+        repo: 'api',
+        path: 'package.json',
+      }),
+    );
+  });
+
   it('disconnects an installation and deletes its repositories with cascade', async () => {
     workspaceRepository.find.mockResolvedValue([{id: 9}]);
     githubRepositoryRepository.find.mockResolvedValue([

--- a/api/src/__tests__/unit/services/github.service.test.ts
+++ b/api/src/__tests__/unit/services/github.service.test.ts
@@ -460,6 +460,43 @@ describe('GithubService (unit)', () => {
     );
   });
 
+  it('rejects malformed repository names for repository context lookups', async () => {
+    await expect(service.getRepositoryOverview(4, 'api')).rejects.toThrow(
+      'Unable to resolve repository owner/name for repository overview lookup',
+    );
+    await expect(service.listRepositoryDirectory(4, 'api')).rejects.toThrow(
+      'Unable to resolve repository owner/name for repository directory lookup',
+    );
+    await expect(
+      service.getRepositoryFileContents(4, 'api', 'package.json'),
+    ).rejects.toThrow(
+      'Unable to resolve repository owner/name for repository file content lookup',
+    );
+  });
+
+  it('handles non-directory and raw-string repository content responses', async () => {
+    const octokit = {
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({data: {type: 'file'}})
+        .mockResolvedValueOnce({data: 'raw contents'})
+        .mockResolvedValueOnce({data: {type: 'dir'}}),
+    };
+    vi.spyOn(internals, 'getInstallationClient').mockResolvedValue(
+      octokit as never,
+    );
+
+    await expect(
+      service.listRepositoryDirectory(4, 'team/api', 'package.json'),
+    ).resolves.toEqual([]);
+    await expect(
+      service.getRepositoryFileContents(4, 'team/api', 'README.md'),
+    ).resolves.toBe('raw contents');
+    await expect(
+      service.getRepositoryFileContents(4, 'team/api', 'src'),
+    ).resolves.toBe('');
+  });
+
   it('disconnects an installation and deletes its repositories with cascade', async () => {
     workspaceRepository.find.mockResolvedValue([{id: 9}]);
     githubRepositoryRepository.find.mockResolvedValue([

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -5,20 +5,47 @@ describe('IssuePriorityService (unit)', () => {
   let ollamaService: {
     chatJson: ReturnType<typeof vi.fn>;
   };
+  let githubService: {
+    getRepositoryOverview: ReturnType<typeof vi.fn>;
+    listRepositoryDirectory: ReturnType<typeof vi.fn>;
+    getRepositoryFileContents: ReturnType<typeof vi.fn>;
+  };
   let service: IssuePriorityService;
 
   beforeEach(() => {
     ollamaService = {
       chatJson: vi.fn(),
     };
+    githubService = {
+      getRepositoryOverview: vi.fn().mockResolvedValue({
+        name: 'api',
+        full_name: 'team/api',
+        description: 'LoopBack backend',
+        default_branch: 'main',
+        language: 'TypeScript',
+        topics: ['loopback', 'api'],
+        open_issues_count: 0,
+      }),
+      listRepositoryDirectory: vi.fn().mockResolvedValue([
+        {name: 'package.json', path: 'package.json', type: 'file', size: 200},
+        {name: 'src', path: 'src', type: 'dir'},
+      ]),
+      getRepositoryFileContents: vi.fn().mockResolvedValue('{}'),
+    };
 
-    service = new IssuePriorityService(ollamaService as never);
+    service = new IssuePriorityService(
+      ollamaService as never,
+      (async () => githubService as never) as never,
+    );
   });
 
   it('normalizes the model response into a valid prediction', async () => {
     ollamaService.chatJson.mockResolvedValue({
+      type: 'final',
       priority: 'veryhigh',
       reason: 'Authentication bypass is explicitly confirmed.',
+      estimated_hours: 8.4,
+      estimation_confidence: 'MEDIUM',
     });
 
     await expect(
@@ -29,6 +56,8 @@ describe('IssuePriorityService (unit)', () => {
     ).resolves.toEqual({
       priority: 'Very-High',
       reason: 'Authentication bypass is explicitly confirmed.',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
     });
   });
 
@@ -36,15 +65,20 @@ describe('IssuePriorityService (unit)', () => {
     const withNote = service.upsertPredictionNote('Original description', {
       priority: 'High',
       reason: 'The billing module is unusable.',
+      estimatedHours: 4,
+      estimationConfidence: 'high',
     });
 
     const updated = service.upsertPredictionNote(withNote, {
       priority: 'Medium',
       reason: 'Only one feature is broken.',
+      estimatedHours: 2,
+      estimationConfidence: 'medium',
     });
 
     expect(updated).toContain('Original description');
     expect(updated).toContain('AI priority prediction: Medium');
+    expect(updated).toContain('Estimated effort: 2h (medium confidence)');
     expect(updated).not.toContain('AI priority prediction: High');
   });
 
@@ -59,7 +93,57 @@ describe('IssuePriorityService (unit)', () => {
     ).resolves.toEqual({
       priority: 'Unknown',
       reason: 'AI prioritization unavailable.',
+      estimatedHours: null,
+      estimationConfidence: 'low',
     });
+  });
+
+  it('can inspect repository context before producing an estimate', async () => {
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_file_contents',
+        arguments: {path: 'package.json'},
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'High',
+        reason:
+          'The repository uses LoopBack service layers and auth concerns usually span multiple files.',
+        estimated_hours: 8,
+        estimation_confidence: 'high',
+      });
+
+    await expect(
+      service.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Broken login',
+        description: 'Users cannot authenticate through the main login flow.',
+      }),
+    ).resolves.toEqual({
+      priority: 'High',
+      reason:
+        'The repository uses LoopBack service layers and auth concerns usually span multiple files.',
+      estimatedHours: 8,
+      estimationConfidence: 'high',
+    });
+
+    expect(githubService.getRepositoryOverview).toHaveBeenCalledWith(
+      11,
+      'team/api',
+    );
+    expect(githubService.listRepositoryDirectory).toHaveBeenCalledWith(
+      11,
+      'team/api',
+      '',
+    );
+    expect(githubService.getRepositoryFileContents).toHaveBeenCalledWith(
+      11,
+      'team/api',
+      'package.json',
+    );
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(2);
   });
 
   it('can write a merge-risk note for pull requests', () => {

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -228,6 +228,134 @@ describe('IssuePriorityService (unit)', () => {
     );
   });
 
+  it('keeps tool-assisted prediction resilient across invalid tool responses', async () => {
+    const longFile = 'x'.repeat(7000);
+    githubService.getRepositoryOverview
+      .mockResolvedValueOnce({
+        name: 'api',
+        full_name: 'team/api',
+        description: 'LoopBack backend',
+        default_branch: 'main',
+        language: 'TypeScript',
+        topics: ['loopback', 'api'],
+        open_issues_count: 0,
+      })
+      .mockResolvedValueOnce({
+        name: 'api',
+        full_name: 'team/api',
+        description: null,
+        default_branch: null,
+        language: null,
+        topics: [],
+        open_issues_count: 0,
+      })
+      .mockRejectedValueOnce('overview failed');
+    githubService.listRepositoryDirectory
+      .mockResolvedValueOnce([
+        {name: 'package.json', path: 'package.json', type: 'file', size: 200},
+      ])
+      .mockResolvedValueOnce([
+        {name: 'src', path: 'src', type: 'dir'},
+        {name: 'test', path: 'test', type: 'dir'},
+      ]);
+    githubService.getRepositoryFileContents
+      .mockResolvedValueOnce(longFile)
+      .mockRejectedValueOnce('file failed');
+    ollamaService.chatJson
+      .mockResolvedValueOnce({nonsense: true})
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'unknown_tool',
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_overview',
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_overview',
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'list_repository_directory',
+        arguments: {path: 'src', limit: 1.9},
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_file_contents',
+        arguments: {path: ''},
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_file_contents',
+        arguments: {path: 'src/index.ts'},
+      })
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_file_contents',
+        arguments: {path: 'src/missing.ts'},
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'Low',
+        reason: 'The available evidence indicates a small contained issue.',
+        estimated_hours: 300,
+        estimation_confidence: 'certain',
+      });
+
+    await expect(
+      service.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Minor config cleanup',
+        description: 'One config file needs cleanup.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Low',
+      reason: 'The available evidence indicates a small contained issue.',
+      estimatedHours: null,
+      estimationConfidence: null,
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(9);
+    expect(ollamaService.chatJson.mock.calls[8][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('unknown_tool'),
+        }),
+        expect.objectContaining({
+          content: expect.stringContaining('Unknown tool execution error.'),
+        }),
+        expect.objectContaining({
+          content: expect.stringContaining('[truncated]'),
+        }),
+      ]),
+    );
+  });
+
+  it('falls back when the model exceeds the tool-call budget', async () => {
+    ollamaService.chatJson.mockResolvedValue({
+      type: 'tool_call',
+      tool: 'get_repository_overview',
+    });
+
+    await expect(
+      service.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Looping estimate',
+        description: 'The model keeps asking for tools.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Unknown',
+      reason: 'AI prioritization unavailable.',
+      estimatedHours: null,
+      estimationConfidence: 'low',
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(9);
+  });
+
   it('can write a merge-risk note for pull requests', () => {
     const updated = service.upsertPredictionNote(
       'Original description',

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -356,6 +356,98 @@ describe('IssuePriorityService (unit)', () => {
     expect(ollamaService.chatJson).toHaveBeenCalledTimes(9);
   });
 
+  it('continues when GitHub service is not bound', async () => {
+    const serviceWithoutGithub = new IssuePriorityService(
+      ollamaService as never,
+      (async () => undefined) as never,
+    );
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_overview',
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'Medium',
+        reason: 'The issue text is enough to classify one broken workflow.',
+      });
+
+    await expect(
+      serviceWithoutGithub.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Broken export',
+        description: 'The billing export workflow fails.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Medium',
+      reason: 'The issue text is enough to classify one broken workflow.',
+      estimatedHours: null,
+      estimationConfidence: null,
+    });
+
+    expect(ollamaService.chatJson.mock.calls[1][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('GitHub service is unavailable'),
+        }),
+      ]),
+    );
+  });
+
+  it('returns structured tool errors when repository context is missing', async () => {
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_repository_overview',
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'Low',
+        reason: 'The issue text still indicates a small fix.',
+      });
+
+    await expect(
+      service.predictIssuePriority({
+        title: 'Typo',
+        description: 'A label is misspelled.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Low',
+      reason: 'The issue text still indicates a small fix.',
+      estimatedHours: null,
+      estimationConfidence: null,
+    });
+
+    expect(ollamaService.chatJson.mock.calls[1][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining(
+            'GitHub installation context is unavailable',
+          ),
+        }),
+      ]),
+    );
+  });
+
+  it('falls back after repeated invalid non-tool responses', async () => {
+    ollamaService.chatJson.mockResolvedValue({nonsense: true});
+
+    await expect(
+      service.predictIssuePriority({
+        title: 'Invalid loop',
+        description: 'The model keeps returning invalid JSON shapes.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Unknown',
+      reason: 'AI prioritization unavailable.',
+      estimatedHours: null,
+      estimationConfidence: 'low',
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(9);
+  });
+
   it('can write a merge-risk note for pull requests', () => {
     const updated = service.upsertPredictionNote(
       'Original description',

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -146,6 +146,88 @@ describe('IssuePriorityService (unit)', () => {
     expect(ollamaService.chatJson).toHaveBeenCalledTimes(2);
   });
 
+  it('continues with issue text when initial repository evidence fails', async () => {
+    githubService.getRepositoryOverview.mockRejectedValueOnce(
+      new Error('GitHub API unavailable'),
+    );
+    ollamaService.chatJson.mockResolvedValue({
+      type: 'final',
+      priority: 'Medium',
+      reason: 'The issue still describes one broken workflow.',
+      estimated_hours: 3,
+      estimation_confidence: 'low',
+    });
+
+    await expect(
+      service.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Broken billing export',
+        description: 'The CSV export fails for billing reports.',
+      }),
+    ).resolves.toEqual({
+      priority: 'Medium',
+      reason: 'The issue still describes one broken workflow.',
+      estimatedHours: 3,
+      estimationConfidence: 'low',
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(1);
+    expect(ollamaService.chatJson.mock.calls[0][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining(
+            'Repository evidence is unavailable',
+          ),
+        }),
+      ]),
+    );
+  });
+
+  it('returns directory tool errors without aborting prediction', async () => {
+    githubService.listRepositoryDirectory
+      .mockResolvedValueOnce([
+        {name: 'package.json', path: 'package.json', type: 'file', size: 200},
+      ])
+      .mockRejectedValueOnce(new Error('Directory not found'));
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'list_repository_directory',
+        arguments: {path: 'missing'},
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'High',
+        reason: 'The issue still blocks the authentication module.',
+        estimated_hours: 8,
+        estimation_confidence: 'medium',
+      });
+
+    await expect(
+      service.predictIssuePriority({
+        installationId: 11,
+        repositoryFullName: 'team/api',
+        title: 'Broken login',
+        description: 'Users cannot authenticate through the main login flow.',
+      }),
+    ).resolves.toEqual({
+      priority: 'High',
+      reason: 'The issue still blocks the authentication module.',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenCalledTimes(2);
+    expect(ollamaService.chatJson.mock.calls[1][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('Directory not found'),
+        }),
+      ]),
+    );
+  });
+
   it('can write a merge-risk note for pull requests', () => {
     const updated = service.upsertPredictionNote(
       'Original description',

--- a/api/src/__tests__/unit/services/issue.service.test.ts
+++ b/api/src/__tests__/unit/services/issue.service.test.ts
@@ -246,6 +246,21 @@ describe('IssueService (unit)', () => {
     });
   });
 
+  it('skips associated data cleanup when no issues match deletion', async () => {
+    githubIssueRepository.find.mockResolvedValue([]);
+    githubIssueRepository.deleteAll.mockResolvedValue({count: 0});
+
+    await expect(service.deleteAll({repositoryId: 99})).resolves.toEqual({
+      count: 0,
+    });
+
+    expect(aiPredictionService.deleteForSources).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.deleteAll).not.toHaveBeenCalled();
+    expect(githubIssueRepository.deleteAll).toHaveBeenCalledWith({
+      repositoryId: 99,
+    });
+  });
+
   it('saves issues in batches of 100', async () => {
     const issues = Array.from({length: 205}, (_, index) => ({
       issue: {

--- a/api/src/__tests__/unit/services/issue.service.test.ts
+++ b/api/src/__tests__/unit/services/issue.service.test.ts
@@ -91,6 +91,8 @@ describe('IssueService (unit)', () => {
       {
         priority: 'High',
         reason: 'Critical workflow is blocked.',
+        estimatedHours: 8,
+        estimationConfidence: 'medium',
       },
     );
 
@@ -100,6 +102,8 @@ describe('IssueService (unit)', () => {
       predictionType: 'issue-priority',
       priority: 'High',
       reason: 'Critical workflow is blocked.',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
     });
   });
 
@@ -146,6 +150,8 @@ describe('IssueService (unit)', () => {
       {
         priority: 'Low',
         reason: 'Already mitigated.',
+        estimatedHours: 1,
+        estimationConfidence: 'high',
       },
     );
 
@@ -155,6 +161,8 @@ describe('IssueService (unit)', () => {
       predictionType: 'issue-priority',
       priority: 'Low',
       reason: 'Already mitigated.',
+      estimatedHours: 1,
+      estimationConfidence: 'high',
     });
   });
 
@@ -232,6 +240,8 @@ describe('IssueService (unit)', () => {
       prediction: {
         priority: 'Medium',
         reason: `Reason ${index + 1}`,
+        estimatedHours: 4,
+        estimationConfidence: 'medium' as const,
       },
     }));
 

--- a/api/src/__tests__/unit/services/issue.service.test.ts
+++ b/api/src/__tests__/unit/services/issue.service.test.ts
@@ -17,6 +17,9 @@ describe('IssueService (unit)', () => {
     createPredictionsBulk: ReturnType<typeof vi.fn>;
     deleteForSources: ReturnType<typeof vi.fn>;
   };
+  let issueAssignmentRepository: {
+    deleteAll: ReturnType<typeof vi.fn>;
+  };
   let service: IssueService;
 
   beforeEach(() => {
@@ -39,9 +42,13 @@ describe('IssueService (unit)', () => {
       createPredictionsBulk: vi.fn().mockResolvedValue(undefined),
       deleteForSources: vi.fn().mockResolvedValue(undefined),
     };
+    issueAssignmentRepository = {
+      deleteAll: vi.fn().mockResolvedValue(undefined),
+    };
 
     service = new IssueService(
       githubIssueRepository as never,
+      issueAssignmentRepository as never,
       aiPredictionService as never,
     );
   });
@@ -176,6 +183,9 @@ describe('IssueService (unit)', () => {
       [4, 8],
       'issue-priority',
     );
+    expect(issueAssignmentRepository.deleteAll).toHaveBeenCalledWith({
+      issueId: {inq: [4, 8]},
+    });
     expect(githubIssueRepository.deleteAll).toHaveBeenCalledWith({
       repositoryId: 1,
       githubId: 2,
@@ -192,6 +202,9 @@ describe('IssueService (unit)', () => {
       [10, 20],
       'issue-priority',
     );
+    expect(issueAssignmentRepository.deleteAll).toHaveBeenCalledWith({
+      issueId: {inq: [10, 20]},
+    });
     expect(githubIssueRepository.deleteAll).toHaveBeenCalledWith({
       repositoryId: 7,
     });
@@ -207,6 +220,9 @@ describe('IssueService (unit)', () => {
       [11],
       'issue-priority',
     );
+    expect(issueAssignmentRepository.deleteAll).toHaveBeenCalledWith({
+      issueId: {inq: [11]},
+    });
     expect(githubIssueRepository.deleteAll).toHaveBeenCalledWith({id: 11});
   });
 
@@ -222,6 +238,9 @@ describe('IssueService (unit)', () => {
       [4, 8],
       'issue-priority',
     );
+    expect(issueAssignmentRepository.deleteAll).toHaveBeenCalledWith({
+      issueId: {inq: [4, 8]},
+    });
     expect(githubIssueRepository.deleteAll).toHaveBeenCalledWith({
       repositoryId: 1,
     });

--- a/api/src/__tests__/unit/services/pull-request-merge-risk.service.test.ts
+++ b/api/src/__tests__/unit/services/pull-request-merge-risk.service.test.ts
@@ -284,6 +284,154 @@ describe('PullRequestMergeRiskService (unit)', () => {
     );
   });
 
+  it('can grep changed files before producing the final prediction', async () => {
+    githubService.getPullRequestOverview.mockResolvedValue({
+      changed_files: 2,
+      additions: 10,
+      deletions: 2,
+      commits: 1,
+      draft: false,
+      mergeable_state: 'clean',
+      head_ref: 'feature/auth',
+      base_ref: 'main',
+    });
+    githubService.listPullRequestFiles.mockResolvedValue([
+      {
+        filename: 'src/auth/guard.ts',
+        status: 'modified',
+        additions: 8,
+        deletions: 2,
+        changes: 10,
+        patch: '@@ -1,1 +1,2 @@\n+const authBypass = true;',
+      },
+      {
+        filename: 'src/ui/button.ts',
+        status: 'modified',
+        additions: 2,
+        deletions: 0,
+        changes: 2,
+        patch: '@@ -1,1 +1,2 @@\n+const variant = "primary";',
+      },
+    ]);
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'grep_pull_request_changes',
+        arguments: {query: 'auth', limit: 3},
+        reason: 'Need to inspect auth-related changes.',
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'High',
+        reason: 'The PR touches authentication guard behavior.',
+        findings: [],
+      });
+
+    await expect(
+      service.predictMergeRisk({
+        installationId: 12,
+        repositoryFullName: 'team/api',
+        pullRequestNumber: 45,
+        title: 'Adjust auth guard',
+        description: 'Touches login guard behavior.',
+      }),
+    ).resolves.toEqual({
+      priority: 'High',
+      reason: 'The PR touches authentication guard behavior.',
+      findings: [],
+      reviewerExpertiseSuggestions: [],
+      reviewerSuggestions: [],
+    });
+
+    expect(ollamaService.chatJson).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('"query":"auth"'),
+          }),
+          expect.objectContaining({
+            content: expect.stringContaining('src/auth/guard.ts'),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('can read pull request file contents before producing the final prediction', async () => {
+    githubService.getPullRequestOverview.mockResolvedValue({
+      changed_files: 1,
+      additions: 8,
+      deletions: 2,
+      commits: 1,
+      draft: false,
+      mergeable_state: 'clean',
+      head_ref: 'feature/auth',
+      base_ref: 'main',
+    });
+    githubService.listPullRequestFiles.mockResolvedValue([
+      {
+        filename: 'src/auth/guard.ts',
+        status: 'modified',
+        additions: 8,
+        deletions: 2,
+        changes: 10,
+        patch: '@@ -1,1 +1,2 @@\n+const authBypass = true;',
+      },
+    ]);
+    githubService.getPullRequestFileContents.mockResolvedValue(
+      'export function guard() { return true; }',
+    );
+    ollamaService.chatJson
+      .mockResolvedValueOnce({
+        type: 'tool_call',
+        tool: 'get_pull_request_file_contents',
+        arguments: {path: 'src/auth/guard.ts'},
+        reason: 'Need full guard context.',
+      })
+      .mockResolvedValueOnce({
+        type: 'final',
+        priority: 'High',
+        reason: 'The PR touches authentication guard behavior.',
+        findings: [],
+      });
+
+    await expect(
+      service.predictMergeRisk({
+        installationId: 12,
+        repositoryFullName: 'team/api',
+        pullRequestNumber: 45,
+        title: 'Adjust auth guard',
+        description: 'Touches login guard behavior.',
+      }),
+    ).resolves.toEqual({
+      priority: 'High',
+      reason: 'The PR touches authentication guard behavior.',
+      findings: [],
+      reviewerExpertiseSuggestions: [],
+      reviewerSuggestions: [],
+    });
+
+    expect(githubService.getPullRequestFileContents).toHaveBeenCalledWith(
+      12,
+      'team/api',
+      45,
+      'src/auth/guard.ts',
+    );
+    expect(ollamaService.chatJson).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining(
+              'export function guard() { return true; }',
+            ),
+          }),
+        ]),
+      }),
+    );
+  });
+
   it('drops malformed review findings from the AI response', async () => {
     githubService.getPullRequestOverview.mockResolvedValue({
       changed_files: 1,

--- a/api/src/controllers/github/issue.controller.ts
+++ b/api/src/controllers/github/issue.controller.ts
@@ -65,9 +65,13 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
   ): Promise<IssuePriorityPrediction> {
     const {title, description} = this.validateDraft(body);
 
-    await this.getRepositoryContext(body.repositoryId);
+    const repositoryContext = await this.getRepositoryContext(
+      body.repositoryId,
+    );
 
     return this.issuePriorityService.predictIssuePriority({
+      installationId: repositoryContext.installationId,
+      repositoryFullName: repositoryContext.repository.fullName,
       title,
       description,
     });

--- a/api/src/models/system/ai-prediction.model.ts
+++ b/api/src/models/system/ai-prediction.model.ts
@@ -26,6 +26,14 @@ export type AIPredictionReviewerSuggestion = {
   reason: string;
 };
 
+export const AI_ESTIMATION_CONFIDENCE_VALUES = [
+  'low',
+  'medium',
+  'high',
+] as const;
+export type AIEstimationConfidence =
+  (typeof AI_ESTIMATION_CONFIDENCE_VALUES)[number];
+
 @model({
   settings: {
     forceId: false,
@@ -92,6 +100,22 @@ export class AIPrediction extends Entity {
     postgresql: {columnName: 'reviewer_suggestions', dataType: 'jsonb'},
   })
   reviewerSuggestions?: AIPredictionReviewerSuggestion[];
+
+  @property({
+    type: 'number',
+    jsonSchema: {type: 'integer'},
+    postgresql: {columnName: 'estimated_hours'},
+  })
+  estimatedHours?: number | null;
+
+  @property({
+    type: 'string',
+    jsonSchema: {
+      enum: [...AI_ESTIMATION_CONFIDENCE_VALUES],
+    },
+    postgresql: {columnName: 'estimation_confidence'},
+  })
+  estimationConfidence?: AIEstimationConfidence | null;
 
   @property({
     type: 'date',

--- a/api/src/repositories/github/repository.repository.ts
+++ b/api/src/repositories/github/repository.repository.ts
@@ -19,6 +19,7 @@ import {GithubIssueRepository} from './issue.repository';
 import {GithubLabelRepository} from './label.repository';
 import {GithubPullRequestRepository} from './pull-request.repository';
 import {AIPredictionRepository, WorkspaceRepository} from '../system';
+import {IssueAssignmentRepository} from '../planning';
 
 export class GithubRepositoryRepository extends DefaultCrudRepository<
   GithubRepository,
@@ -29,6 +30,7 @@ export class GithubRepositoryRepository extends DefaultCrudRepository<
   private readonly githubLabelRepositoryGetter: Getter<GithubLabelRepository>;
   private readonly githubPullRequestRepositoryGetter: Getter<GithubPullRequestRepository>;
   private readonly aiPredictionRepositoryGetter: Getter<AIPredictionRepository>;
+  private readonly issueAssignmentRepositoryGetter: Getter<IssueAssignmentRepository>;
   public readonly workspace: BelongsToAccessor<
     Workspace,
     typeof GithubRepository.prototype.id
@@ -58,12 +60,15 @@ export class GithubRepositoryRepository extends DefaultCrudRepository<
     githubPullRequestRepositoryGetter: Getter<GithubPullRequestRepository>,
     @repository.getter('AIPredictionRepository')
     aiPredictionRepositoryGetter: Getter<AIPredictionRepository>,
+    @repository.getter('IssueAssignmentRepository')
+    issueAssignmentRepositoryGetter: Getter<IssueAssignmentRepository>,
   ) {
     super(GithubRepository, dataSource);
     this.githubIssueRepositoryGetter = githubIssueRepositoryGetter;
     this.githubLabelRepositoryGetter = githubLabelRepositoryGetter;
     this.githubPullRequestRepositoryGetter = githubPullRequestRepositoryGetter;
     this.aiPredictionRepositoryGetter = aiPredictionRepositoryGetter;
+    this.issueAssignmentRepositoryGetter = issueAssignmentRepositoryGetter;
 
     this.workspace = this.createBelongsToAccessorFor(
       'workspace',
@@ -94,6 +99,8 @@ export class GithubRepositoryRepository extends DefaultCrudRepository<
     const githubPullRequestRepository =
       await this.githubPullRequestRepositoryGetter();
     const aiPredictionRepository = await this.aiPredictionRepositoryGetter();
+    const issueAssignmentRepository =
+      await this.issueAssignmentRepositoryGetter();
     const issues = await githubIssueRepository.find({where: {repositoryId}});
     const pullRequests = await githubPullRequestRepository.find({
       where: {repositoryId},
@@ -108,6 +115,9 @@ export class GithubRepositoryRepository extends DefaultCrudRepository<
       sourceType: 'github-pull-request',
       sourceId: {inq: pullRequests.map(pullRequest => pullRequest.id)},
       predictionType: 'pull-request-merge-risk',
+    });
+    await issueAssignmentRepository.deleteAll({
+      issueId: {inq: issues.map(issue => issue.id)},
     });
     await githubIssueRepository.deleteAll({repositoryId});
     await githubLabelRepository.deleteAll({repositoryId});

--- a/api/src/services/ai-prediction.service.ts
+++ b/api/src/services/ai-prediction.service.ts
@@ -2,6 +2,7 @@ import {BindingScope, injectable} from '@loopback/core';
 import {DataObject, repository} from '@loopback/repository';
 import {
   AIPrediction,
+  AIEstimationConfidence,
   AIPredictionFinding,
   AIPredictionReviewerSuggestion,
   AIPredictionSourceType,
@@ -17,6 +18,8 @@ export type AIPredictionWrite = {
   reason?: string | null;
   findings?: AIPredictionFinding[] | null;
   reviewerSuggestions?: AIPredictionReviewerSuggestion[] | null;
+  estimatedHours?: number | null;
+  estimationConfidence?: AIEstimationConfidence | null;
 };
 
 type NormalizedAIPredictionWrite = {
@@ -27,6 +30,8 @@ type NormalizedAIPredictionWrite = {
   reason?: string;
   findings?: AIPredictionFinding[];
   reviewerSuggestions?: AIPredictionReviewerSuggestion[];
+  estimatedHours?: number;
+  estimationConfidence?: AIEstimationConfidence;
 };
 
 @injectable({scope: BindingScope.SINGLETON})
@@ -61,6 +66,8 @@ export class AIPredictionService {
       reason: prediction.reason,
       findings: prediction.findings,
       reviewerSuggestions: prediction.reviewerSuggestions,
+      estimatedHours: prediction.estimatedHours,
+      estimationConfidence: prediction.estimationConfidence,
     });
   }
 
@@ -123,6 +130,12 @@ export class AIPredictionService {
       reason: input.reason?.trim() || undefined,
       findings: input.findings ?? undefined,
       reviewerSuggestions: input.reviewerSuggestions ?? undefined,
+      estimatedHours:
+        typeof input.estimatedHours === 'number' &&
+        Number.isInteger(input.estimatedHours)
+          ? input.estimatedHours
+          : undefined,
+      estimationConfidence: input.estimationConfidence ?? undefined,
     };
   }
 
@@ -133,7 +146,9 @@ export class AIPredictionService {
       prediction.priority ||
       prediction.reason ||
       prediction.findings?.length ||
-      prediction.reviewerSuggestions?.length,
+      prediction.reviewerSuggestions?.length ||
+      typeof prediction.estimatedHours === 'number' ||
+      prediction.estimationConfidence,
     );
   }
 }

--- a/api/src/services/github-integration/github-webhook.service.ts
+++ b/api/src/services/github-integration/github-webhook.service.ts
@@ -227,6 +227,8 @@ export class GithubWebhookService {
     }
 
     const prediction = await this.issuePriorityService.predictIssuePriority({
+      installationId: payload.installation?.id ?? null,
+      repositoryFullName: repository.fullName,
       title: payload.issue.title,
       description: cleanedDescription,
     });
@@ -247,6 +249,8 @@ export class GithubWebhookService {
       {
         priority: prediction.priority,
         reason: prediction.reason,
+        estimatedHours: prediction.estimatedHours,
+        estimationConfidence: prediction.estimationConfidence,
       },
     );
 

--- a/api/src/services/github-integration/github.service.ts
+++ b/api/src/services/github-integration/github.service.ts
@@ -64,6 +64,23 @@ type GithubRepositoryPullRequest = {
   } | null;
 };
 
+type GithubRepositoryOverview = {
+  name: string;
+  full_name: string;
+  description: string | null;
+  default_branch: string | null;
+  language: string | null;
+  topics: string[];
+  open_issues_count: number;
+};
+
+type GithubRepositoryDirectoryEntry = {
+  name: string;
+  path: string;
+  type: 'file' | 'dir' | 'symlink' | 'submodule' | string;
+  size?: number;
+};
+
 type GithubPullRequestOverview = {
   number: number;
   title: string;
@@ -600,6 +617,133 @@ export class GithubService {
       draft: pullRequest.draft ?? false,
       user: pullRequest.user ? {id: pullRequest.user.id} : null,
     }));
+  }
+
+  public async getRepositoryOverview(
+    installationId: number,
+    repositoryFullName: string,
+  ): Promise<GithubRepositoryOverview> {
+    const repositoryCoordinates = this.getRepositoryCoordinates(
+      repositoryFullName,
+      'repository overview lookup',
+    );
+
+    if (!repositoryCoordinates) {
+      throw new HttpErrors.BadRequest(
+        'Unable to resolve repository owner/name for repository overview lookup',
+      );
+    }
+
+    const {owner, repo} = repositoryCoordinates;
+    const octokit = await this.getInstallationClient(installationId);
+    const response = await octokit.request('GET /repos/{owner}/{repo}', {
+      owner,
+      repo,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    return {
+      name: response.data.name,
+      full_name: response.data.full_name,
+      description: response.data.description ?? null,
+      default_branch: response.data.default_branch ?? null,
+      language: response.data.language ?? null,
+      topics: response.data.topics ?? [],
+      open_issues_count: response.data.open_issues_count ?? 0,
+    };
+  }
+
+  public async listRepositoryDirectory(
+    installationId: number,
+    repositoryFullName: string,
+    path = '',
+  ): Promise<GithubRepositoryDirectoryEntry[]> {
+    const repositoryCoordinates = this.getRepositoryCoordinates(
+      repositoryFullName,
+      'repository directory lookup',
+    );
+
+    if (!repositoryCoordinates) {
+      throw new HttpErrors.BadRequest(
+        'Unable to resolve repository owner/name for repository directory lookup',
+      );
+    }
+
+    const {owner, repo} = repositoryCoordinates;
+    const octokit = await this.getInstallationClient(installationId);
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      {
+        owner,
+        repo,
+        path,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!Array.isArray(response.data)) {
+      return [];
+    }
+
+    return response.data.map(entry => ({
+      name: entry.name,
+      path: entry.path,
+      type: entry.type,
+      size: typeof entry.size === 'number' ? entry.size : undefined,
+    }));
+  }
+
+  public async getRepositoryFileContents(
+    installationId: number,
+    repositoryFullName: string,
+    path: string,
+  ): Promise<string> {
+    const repositoryCoordinates = this.getRepositoryCoordinates(
+      repositoryFullName,
+      'repository file content lookup',
+    );
+
+    if (!repositoryCoordinates) {
+      throw new HttpErrors.BadRequest(
+        'Unable to resolve repository owner/name for repository file content lookup',
+      );
+    }
+
+    const {owner, repo} = repositoryCoordinates;
+    const octokit = await this.getInstallationClient(installationId);
+    const response = await octokit.request(
+      'GET /repos/{owner}/{repo}/contents/{path}',
+      {
+        owner,
+        repo,
+        path,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (typeof response.data === 'string') {
+      return response.data;
+    }
+
+    if (
+      response.data &&
+      typeof response.data === 'object' &&
+      'content' in response.data &&
+      typeof response.data.content === 'string'
+    ) {
+      return Buffer.from(
+        response.data.content,
+        response.data.encoding === 'base64' ? 'base64' : 'utf8',
+      ).toString('utf8');
+    }
+
+    return '';
   }
 
   public async getPullRequestOverview(

--- a/api/src/services/github-integration/issue.service.ts
+++ b/api/src/services/github-integration/issue.service.ts
@@ -7,6 +7,8 @@ import {AIPredictionService} from '../ai-prediction.service';
 type IssuePredictionWrite = {
   priority: string;
   reason: string;
+  estimatedHours?: number | null;
+  estimationConfidence?: 'low' | 'medium' | 'high' | null;
 };
 
 type GithubIssueWrite = {
@@ -53,6 +55,8 @@ export class IssueService {
           predictionType: 'issue-priority',
           priority: prediction.priority,
           reason: prediction.reason,
+          estimatedHours: prediction.estimatedHours,
+          estimationConfidence: prediction.estimationConfidence,
         });
       }
       return;
@@ -67,6 +71,8 @@ export class IssueService {
         predictionType: 'issue-priority',
         priority: prediction.priority,
         reason: prediction.reason,
+        estimatedHours: prediction.estimatedHours,
+        estimationConfidence: prediction.estimationConfidence,
       });
     }
   }
@@ -114,6 +120,9 @@ export class IssueService {
           predictionType: 'issue-priority',
           priority: batch[batchIndex].prediction.priority,
           reason: batch[batchIndex].prediction.reason,
+          estimatedHours: batch[batchIndex].prediction.estimatedHours,
+          estimationConfidence:
+            batch[batchIndex].prediction.estimationConfidence,
         })),
       );
     }

--- a/api/src/services/github-integration/issue.service.ts
+++ b/api/src/services/github-integration/issue.service.ts
@@ -1,7 +1,10 @@
 import {BindingScope, injectable, service} from '@loopback/core';
 import {Count, DataObject, repository, Where} from '@loopback/repository';
 import {GithubIssue} from '../../models';
-import {GithubIssueRepository} from '../../repositories';
+import {
+  GithubIssueRepository,
+  IssueAssignmentRepository,
+} from '../../repositories';
 import {AIPredictionService} from '../ai-prediction.service';
 
 type IssuePredictionWrite = {
@@ -23,6 +26,8 @@ export class IssueService {
   constructor(
     @repository(GithubIssueRepository)
     private githubIssueRepository: GithubIssueRepository,
+    @repository(IssueAssignmentRepository)
+    private issueAssignmentRepository: IssueAssignmentRepository,
     @service(AIPredictionService)
     private aiPredictionService: AIPredictionService,
   ) {}
@@ -31,11 +36,8 @@ export class IssueService {
     const issues = await this.githubIssueRepository.find({
       where: {repositoryId},
     });
-    await this.aiPredictionService.deleteForSources(
-      'github-issue',
-      issues.map(issue => issue.id),
-      'issue-priority',
-    );
+    const issueIds = issues.map(issue => issue.id);
+    await this.deleteAssociatedData(issueIds);
     await this.githubIssueRepository.deleteAll({repositoryId});
   }
 
@@ -79,11 +81,8 @@ export class IssueService {
 
   public async deleteOne(where: Where<GithubIssue>): Promise<void> {
     const issues = await this.githubIssueRepository.find({where});
-    await this.aiPredictionService.deleteForSources(
-      'github-issue',
-      issues.map(issue => issue.id),
-      'issue-priority',
-    );
+    const issueIds = issues.map(issue => issue.id);
+    await this.deleteAssociatedData(issueIds);
     await this.githubIssueRepository.deleteAll(where);
   }
 
@@ -93,11 +92,8 @@ export class IssueService {
 
   public async deleteAll(where: Where<GithubIssue>): Promise<Count> {
     const issues = await this.githubIssueRepository.find({where});
-    await this.aiPredictionService.deleteForSources(
-      'github-issue',
-      issues.map(issue => issue.id),
-      'issue-priority',
-    );
+    const issueIds = issues.map(issue => issue.id);
+    await this.deleteAssociatedData(issueIds);
 
     return this.githubIssueRepository.deleteAll(where);
   }
@@ -126,6 +122,21 @@ export class IssueService {
         })),
       );
     }
+  }
+
+  private async deleteAssociatedData(issueIds: number[]): Promise<void> {
+    if (!issueIds.length) {
+      return;
+    }
+
+    await this.aiPredictionService.deleteForSources(
+      'github-issue',
+      issueIds,
+      'issue-priority',
+    );
+    await this.issueAssignmentRepository.deleteAll({
+      issueId: {inq: issueIds},
+    });
   }
 }
 

--- a/api/src/services/issue-priority.service.ts
+++ b/api/src/services/issue-priority.service.ts
@@ -195,8 +195,8 @@ Don't return anything else!`;
 export class IssuePriorityService {
   constructor(
     @service(OllamaService) private ollamaService: OllamaService,
-    @inject.getter('services.GithubService')
-    private githubServiceGetter: Getter<GithubService>,
+    @inject.getter('services.GithubService', {optional: true})
+    private githubServiceGetter: Getter<GithubService | undefined>,
   ) {}
 
   public async predictIssuePriority({
@@ -412,17 +412,31 @@ export class IssuePriorityService {
     }
 
     const githubService = await this.githubServiceGetter();
-    const [overview, rootEntries] = await Promise.all([
-      githubService.getRepositoryOverview(
-        context.installationId,
-        context.repositoryFullName,
-      ),
-      githubService.listRepositoryDirectory(
-        context.installationId,
-        context.repositoryFullName,
-        '',
-      ),
-    ]);
+
+    if (!githubService) {
+      return 'Repository evidence is unavailable because GitHub service is not bound; estimate using only the issue text.';
+    }
+
+    let overview: Awaited<ReturnType<GithubService['getRepositoryOverview']>>;
+    let rootEntries: Awaited<
+      ReturnType<GithubService['listRepositoryDirectory']>
+    >;
+
+    try {
+      [overview, rootEntries] = await Promise.all([
+        githubService.getRepositoryOverview(
+          context.installationId,
+          context.repositoryFullName,
+        ),
+        githubService.listRepositoryDirectory(
+          context.installationId,
+          context.repositoryFullName,
+          '',
+        ),
+      ]);
+    } catch (error) {
+      return `Repository evidence is unavailable (${summarizeToolExecutionError(error)}), so estimate using only the issue text.`;
+    }
 
     const summarizedEntries = rootEntries
       .slice(0, MAX_INITIAL_DIRECTORY_RESULTS)
@@ -468,31 +482,50 @@ export class IssuePriorityService {
 
     const githubService = await this.githubServiceGetter();
 
+    if (!githubService) {
+      return {
+        error:
+          'GitHub service is unavailable, so repository tools cannot be executed for this issue.',
+      };
+    }
+
     switch (toolName) {
       case 'get_repository_overview':
-        return githubService.getRepositoryOverview(
-          context.installationId,
-          context.repositoryFullName,
-        );
+        try {
+          return await githubService.getRepositoryOverview(
+            context.installationId,
+            context.repositoryFullName,
+          );
+        } catch (error) {
+          return {error: summarizeToolExecutionError(error)};
+        }
       case 'list_repository_directory': {
         const path = typeof args.path === 'string' ? args.path.trim() : '';
         const limit = clampNumber(args.limit, 1, MAX_DIRECTORY_RESULTS, 20);
-        const entries = await githubService.listRepositoryDirectory(
-          context.installationId,
-          context.repositoryFullName,
-          path,
-        );
 
-        console.log('Issue priority AI listed repository directory', {
-          repositoryFullName: context.repositoryFullName,
-          path: path || '.',
-          returnedEntries: entries.slice(0, limit).map(entry => entry.path),
-        });
+        try {
+          const entries = await githubService.listRepositoryDirectory(
+            context.installationId,
+            context.repositoryFullName,
+            path,
+          );
 
-        return {
-          path: path || '.',
-          entries: entries.slice(0, limit),
-        };
+          console.log('Issue priority AI listed repository directory', {
+            repositoryFullName: context.repositoryFullName,
+            path: path || '.',
+            returnedEntries: entries.slice(0, limit).map(entry => entry.path),
+          });
+
+          return {
+            path: path || '.',
+            entries: entries.slice(0, limit),
+          };
+        } catch (error) {
+          return {
+            path: path || '.',
+            error: summarizeToolExecutionError(error),
+          };
+        }
       }
       case 'get_repository_file_contents': {
         const path = typeof args.path === 'string' ? args.path.trim() : '';

--- a/api/src/services/issue-priority.service.ts
+++ b/api/src/services/issue-priority.service.ts
@@ -1,5 +1,13 @@
-import {BindingScope, injectable, service} from '@loopback/core';
+import {
+  BindingScope,
+  Getter,
+  inject,
+  injectable,
+  service,
+} from '@loopback/core';
+import {AIEstimationConfidence} from '../models';
 import {OllamaService} from './ollama.service';
+import type {GithubService} from './github-integration/github.service';
 
 export const ISSUE_PRIORITY_VALUES = [
   'Unknown',
@@ -14,6 +22,8 @@ export type IssuePriority = (typeof ISSUE_PRIORITY_VALUES)[number];
 export type IssuePriorityPrediction = {
   priority: IssuePriority;
   reason: string;
+  estimatedHours?: number | null;
+  estimationConfidence?: AIEstimationConfidence | null;
 };
 
 type PredictionNoteKind = 'priority' | 'risk';
@@ -21,11 +31,48 @@ type PredictionNoteKind = 'priority' | 'risk';
 type PredictIssuePriorityInput = {
   title: string;
   description: string | null;
+  installationId?: number | null;
+  repositoryFullName?: string | null;
+};
+
+type IssuePriorityAiResponse =
+  | {
+      type: 'tool_call';
+      tool: string;
+      arguments?: Record<string, unknown>;
+      reason?: string;
+    }
+  | {
+      type: 'final';
+      priority?: string;
+      reason?: string;
+      estimated_hours?: number | null;
+      estimation_confidence?: string | null;
+    }
+  | {
+      priority?: string;
+      reason?: string;
+      estimated_hours?: number | null;
+      estimation_confidence?: string | null;
+    };
+
+type IssuePriorityToolName =
+  | 'get_repository_overview'
+  | 'list_repository_directory'
+  | 'get_repository_file_contents';
+
+type IssuePriorityMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
 };
 
 const AI_PRIORITY_NOTE_START = '<!-- onlab-ai-priority:start -->';
 const AI_PRIORITY_NOTE_END = '<!-- onlab-ai-priority:end -->';
 const ISSUE_PROCESSING_EMOJI = '👀';
+const MAX_TOOL_CALLS = 8;
+const MAX_DIRECTORY_RESULTS = 30;
+const MAX_FILE_CONTENT_LENGTH = 6000;
+const MAX_INITIAL_DIRECTORY_RESULTS = 20;
 
 const PRIORITY_PROMPT = `You are a senior software reliability engineer.
 
@@ -77,6 +124,26 @@ a security or identity validation problem.
 Server errors (e.g., login page returns 500) are NOT security issues.
 
 ====================
+REPOSITORY CONTEXT
+====================
+
+When repository tools are available, use them to inspect the codebase and infer the repository workframe:
+- language and framework
+- architecture style
+- testing setup
+- repository conventions and best practices implied by config files and structure
+
+Use that repository context to estimate engineering effort more realistically.
+Examples:
+- a LoopBack or Nest backend issue may require controller/service/repository/test changes
+- an Ember or React frontend issue may require component, route, and test updates
+- typed and heavily structured repos usually imply extra integration and test effort
+
+Do not crawl the entire repository.
+Use only the minimum repository inspection needed to ground the estimate.
+Prefer overview, root files, framework config, and a few relevant files over broad exploration.
+
+====================
 STRICT DECISION ORDER
 ====================
 
@@ -95,53 +162,146 @@ Return ONLY valid JSON in this exact format:
 
 {
   "priority": "<Unknown|Low|Medium|High|Very-High>",
-  "reason": "<Reason for the priority classification>"
+  "reason": "<Reason for the priority classification>",
+  "estimated_hours": <integer estimate for engineering fix effort>,
+  "estimation_confidence": "<low|medium|high>"
 }
+
+Estimate only the engineering implementation effort to fix the issue.
+Use rough whole-hour estimates only.
+Do NOT use decimals.
+Good examples: 1, 2, 4, 8, 16, 24, 40.
+If the issue is too vague to estimate safely, use null or omit the field and set estimation_confidence to "low".
+
+When tools are available, you may inspect the repository before answering.
+Use tools only when they materially improve the estimate.
+
+When you want to use a tool, return ONLY JSON like:
+{
+  "type": "tool_call",
+  "tool": "<tool name>",
+  "arguments": { ... },
+  "reason": "<why you need it>"
+}
+
+Available tools:
+- get_repository_overview: no arguments
+- list_repository_directory: optional arguments { "path"?: string, "limit"?: number }
+- get_repository_file_contents: required arguments { "path": string }
 
 Don't return anything else!`;
 
 @injectable({scope: BindingScope.SINGLETON})
 export class IssuePriorityService {
-  constructor(@service(OllamaService) private ollamaService: OllamaService) {}
+  constructor(
+    @service(OllamaService) private ollamaService: OllamaService,
+    @inject.getter('services.GithubService')
+    private githubServiceGetter: Getter<GithubService>,
+  ) {}
 
   public async predictIssuePriority({
     title,
     description,
+    installationId,
+    repositoryFullName,
   }: PredictIssuePriorityInput): Promise<IssuePriorityPrediction> {
     const cleanDescription = this.sanitizeIssueDescription(description);
+    const messages: IssuePriorityMessage[] = [
+      {
+        role: 'system',
+        content: PRIORITY_PROMPT,
+      },
+      {
+        role: 'user',
+        content: [
+          repositoryFullName ? `Repository: ${repositoryFullName}` : null,
+          `Issue title: ${title}`,
+          `Issue description:\n${cleanDescription || '(empty)'}`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      },
+    ];
 
     try {
-      const response = await this.ollamaService.chatJson<{
-        priority?: string;
-        reason?: string;
-      }>({
-        messages: [
-          {
-            role: 'system',
-            content: PRIORITY_PROMPT,
-          },
-          {
-            role: 'user',
-            content: `Issue title: ${title}\nIssue description:\n${cleanDescription || '(empty)'}`,
-          },
-        ],
+      messages.push({
+        role: 'user',
+        content: await this.buildInitialEvidenceMessage({
+          installationId,
+          repositoryFullName,
+        }),
       });
 
-      return this.normalizePrediction(response);
-    } catch (error) {
-      console.warn(
-        'Issue priority prediction failed, falling back to Unknown',
-        {
-          title,
-          error,
-        },
-      );
+      for (let iteration = 1; iteration <= MAX_TOOL_CALLS + 1; iteration += 1) {
+        const response =
+          await this.ollamaService.chatJson<IssuePriorityAiResponse>({
+            messages,
+          });
 
-      return {
-        priority: 'Unknown',
-        reason: 'AI prioritization unavailable.',
-      };
+        if (isFinalResponse(response)) {
+          return this.normalizePrediction(response);
+        }
+
+        if (!isToolCallResponse(response)) {
+          messages.push({
+            role: 'assistant',
+            content: JSON.stringify(response),
+          });
+          messages.push({
+            role: 'user',
+            content:
+              'Your response was invalid. Return either a tool_call JSON object or a final JSON object.',
+          });
+          continue;
+        }
+
+        if (iteration > MAX_TOOL_CALLS) {
+          return this.fallbackPrediction(
+            title,
+            new Error('AI exceeded the maximum number of tool calls'),
+          );
+        }
+
+        const toolName = normalizeToolName(response.tool);
+
+        if (!toolName) {
+          messages.push({
+            role: 'assistant',
+            content: JSON.stringify(response),
+          });
+          messages.push({
+            role: 'user',
+            content: `The tool "${response.tool}" is not available. Choose a listed tool or return a final answer.`,
+          });
+          continue;
+        }
+
+        const toolResult = await this.executeTool(
+          toolName,
+          response.arguments ?? {},
+          {
+            installationId,
+            repositoryFullName,
+          },
+        );
+
+        messages.push({
+          role: 'assistant',
+          content: JSON.stringify(response),
+        });
+        messages.push({
+          role: 'user',
+          content: `Tool result for ${toolName}:\n${JSON.stringify(toolResult)}`,
+        });
+      }
+    } catch (error) {
+      return this.fallbackPrediction(title, error);
     }
+
+    return this.fallbackPrediction(
+      title,
+      new Error('AI issue prioritization ended without a final response'),
+    );
   }
 
   public sanitizeIssueDescription(
@@ -180,6 +340,9 @@ export class IssuePriorityService {
       '> [!NOTE]',
       `> ${predictionLabel}: ${prediction.priority}`,
       `> Reason: ${prediction.reason}`,
+      prediction.estimatedHours
+        ? `> Estimated effort: ${prediction.estimatedHours}h (${prediction.estimationConfidence ?? 'unknown'} confidence)`
+        : null,
       '> Written by `DevTeams`',
       AI_PRIORITY_NOTE_END,
     ].join('\n');
@@ -208,13 +371,160 @@ export class IssuePriorityService {
   private normalizePrediction(response: {
     priority?: string;
     reason?: string;
+    estimated_hours?: number | null;
+    estimation_confidence?: string | null;
   }): IssuePriorityPrediction {
     const priority = normalizeIssuePriority(response.priority);
 
     return {
       priority: priority ?? 'Unknown',
       reason: response.reason?.trim() || 'Missing classification reason.',
+      estimatedHours: normalizeEstimatedHours(response.estimated_hours),
+      estimationConfidence: normalizeEstimationConfidence(
+        response.estimation_confidence,
+      ),
     };
+  }
+
+  private fallbackPrediction(
+    title: string,
+    error: unknown,
+  ): IssuePriorityPrediction {
+    console.warn('Issue priority prediction failed, falling back to Unknown', {
+      title,
+      error,
+    });
+
+    return {
+      priority: 'Unknown',
+      reason: 'AI prioritization unavailable.',
+      estimatedHours: null,
+      estimationConfidence: 'low',
+    };
+  }
+
+  private async buildInitialEvidenceMessage(context: {
+    installationId?: number | null;
+    repositoryFullName?: string | null;
+  }): Promise<string> {
+    if (!context.installationId || !context.repositoryFullName) {
+      return 'Repository evidence is unavailable, so estimate using only the issue text.';
+    }
+
+    const githubService = await this.githubServiceGetter();
+    const [overview, rootEntries] = await Promise.all([
+      githubService.getRepositoryOverview(
+        context.installationId,
+        context.repositoryFullName,
+      ),
+      githubService.listRepositoryDirectory(
+        context.installationId,
+        context.repositoryFullName,
+        '',
+      ),
+    ]);
+
+    const summarizedEntries = rootEntries
+      .slice(0, MAX_INITIAL_DIRECTORY_RESULTS)
+      .map(entry =>
+        [
+          `- path=${entry.path}`,
+          `type=${entry.type}`,
+          typeof entry.size === 'number' ? `size=${entry.size}` : null,
+        ]
+          .filter(Boolean)
+          .join(' | '),
+      );
+
+    return [
+      'Repository evidence:',
+      [
+        `default_branch=${overview.default_branch ?? 'unknown'}`,
+        `language=${overview.language ?? 'unknown'}`,
+        `topics=${overview.topics.length ? overview.topics.join(', ') : 'none'}`,
+        `description=${overview.description?.trim() || '(empty)'}`,
+      ].join('\n'),
+      'Root directory entries:',
+      summarizedEntries.length
+        ? summarizedEntries.join('\n')
+        : '(no root entries returned)',
+    ].join('\n\n');
+  }
+
+  private async executeTool(
+    toolName: IssuePriorityToolName,
+    args: Record<string, unknown>,
+    context: {
+      installationId?: number | null;
+      repositoryFullName?: string | null;
+    },
+  ): Promise<unknown> {
+    if (!context.installationId || !context.repositoryFullName) {
+      return {
+        error:
+          'GitHub installation context is unavailable, so repository tools cannot be executed for this issue.',
+      };
+    }
+
+    const githubService = await this.githubServiceGetter();
+
+    switch (toolName) {
+      case 'get_repository_overview':
+        return githubService.getRepositoryOverview(
+          context.installationId,
+          context.repositoryFullName,
+        );
+      case 'list_repository_directory': {
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+        const limit = clampNumber(args.limit, 1, MAX_DIRECTORY_RESULTS, 20);
+        const entries = await githubService.listRepositoryDirectory(
+          context.installationId,
+          context.repositoryFullName,
+          path,
+        );
+
+        console.log('Issue priority AI listed repository directory', {
+          repositoryFullName: context.repositoryFullName,
+          path: path || '.',
+          returnedEntries: entries.slice(0, limit).map(entry => entry.path),
+        });
+
+        return {
+          path: path || '.',
+          entries: entries.slice(0, limit),
+        };
+      }
+      case 'get_repository_file_contents': {
+        const path = typeof args.path === 'string' ? args.path.trim() : '';
+
+        if (!path) {
+          return {error: 'The "path" argument is required.'};
+        }
+
+        try {
+          const contents = await githubService.getRepositoryFileContents(
+            context.installationId,
+            context.repositoryFullName,
+            path,
+          );
+
+          console.log('Issue priority AI read repository file', {
+            repositoryFullName: context.repositoryFullName,
+            path,
+          });
+
+          return {
+            path,
+            content: truncateText(contents, MAX_FILE_CONTENT_LENGTH),
+          };
+        } catch (error) {
+          return {
+            path,
+            error: summarizeToolExecutionError(error),
+          };
+        }
+      }
+    }
   }
 }
 
@@ -245,6 +555,103 @@ function normalizeIssuePriority(
   }
 }
 
+function normalizeToolName(
+  value: string | undefined,
+): IssuePriorityToolName | null {
+  switch (value?.trim()) {
+    case 'get_repository_overview':
+      return 'get_repository_overview';
+    case 'list_repository_directory':
+      return 'list_repository_directory';
+    case 'get_repository_file_contents':
+      return 'get_repository_file_contents';
+    default:
+      return null;
+  }
+}
+
+function isToolCallResponse(
+  value: IssuePriorityAiResponse,
+): value is Extract<IssuePriorityAiResponse, {type: 'tool_call'}> {
+  return 'type' in value && value.type === 'tool_call';
+}
+
+function isFinalResponse(
+  value: IssuePriorityAiResponse,
+): value is Exclude<
+  IssuePriorityAiResponse,
+  Extract<IssuePriorityAiResponse, {type: 'tool_call'}>
+> {
+  return (
+    ('type' in value && value.type === 'final') ||
+    (!('type' in value) &&
+      (typeof value.priority === 'string' ||
+        typeof value.reason === 'string' ||
+        typeof value.estimated_hours === 'number' ||
+        value.estimated_hours === null))
+  );
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeEstimatedHours(
+  value: number | null | undefined,
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const normalizedValue = Math.round(value);
+
+  if (normalizedValue <= 0 || normalizedValue > 200) {
+    return null;
+  }
+
+  return normalizedValue;
+}
+
+function normalizeEstimationConfidence(
+  value: string | null | undefined,
+): AIEstimationConfidence | null {
+  switch (value?.trim().toLowerCase()) {
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+      return 'high';
+    default:
+      return null;
+  }
+}
+
+function clampNumber(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength)}\n...[truncated]`;
+}
+
+function summarizeToolExecutionError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  return 'Unknown tool execution error.';
 }

--- a/api/src/services/pull-request-merge-risk.service.ts
+++ b/api/src/services/pull-request-merge-risk.service.ts
@@ -361,6 +361,12 @@ export class PullRequestMergeRiskService {
           context.pullRequestNumber,
         );
 
+        console.log('Pull request merge risk AI listed changed files', {
+          repositoryFullName: context.repositoryFullName,
+          pullRequestNumber: context.pullRequestNumber,
+          returnedFiles: files.slice(0, limit).map(file => file.filename),
+        });
+
         return files.slice(0, limit).map(file => ({
           filename: file.filename,
           status: file.status,
@@ -420,6 +426,13 @@ export class PullRequestMergeRiskService {
             patch: truncateText(file.patch ?? '', MAX_PATCH_SNIPPET_LENGTH),
           }));
 
+        console.log('Pull request merge risk AI grepped changed files', {
+          repositoryFullName: context.repositoryFullName,
+          pullRequestNumber: context.pullRequestNumber,
+          query,
+          matchedFiles: matches.map(file => file.filename),
+        });
+
         return {
           query,
           matches,
@@ -439,6 +452,12 @@ export class PullRequestMergeRiskService {
             context.pullRequestNumber,
             path,
           );
+
+          console.log('Pull request merge risk AI read pull request file', {
+            repositoryFullName: context.repositoryFullName,
+            pullRequestNumber: context.pullRequestNumber,
+            path,
+          });
 
           return {
             path,

--- a/api/src/workers/github.worker.ts
+++ b/api/src/workers/github.worker.ts
@@ -296,6 +296,8 @@ async function processCreateIssueJob(
   );
 
   const prediction = await issuePriorityService.predictIssuePriority({
+    installationId,
+    repositoryFullName: repository.fullName,
     title: job.data.title,
     description: job.data.description,
   });
@@ -539,6 +541,8 @@ async function syncRepositoryIssues(
       );
 
       const prediction = await issuePriorityService.predictIssuePriority({
+        installationId,
+        repositoryFullName: repository.fullName,
         title: githubIssue.title,
         description,
       });

--- a/client/app/components/routes/workspaces/edit/capacity-planning/editor.gts
+++ b/client/app/components/routes/workspaces/edit/capacity-planning/editor.gts
@@ -36,6 +36,8 @@ type SelectedIssue = {
   title: string;
   area: string;
   priority: PriorityTone;
+  estimatedHours: number | null;
+  estimationConfidence: 'low' | 'medium' | 'high' | null;
 };
 
 type AssignmentCard = {
@@ -286,6 +288,8 @@ export default class RoutesWorkspacesEditCapacityPlanningEditor extends Componen
         title: issue.title,
         area: this.issueRepositoryName(issue),
         priority: this.priorityTone(issue.priority),
+        estimatedHours: issue.estimatedHours,
+        estimationConfidence: issue.estimationConfidence,
       }));
   }
 
@@ -476,6 +480,40 @@ export default class RoutesWorkspacesEditCapacityPlanningEditor extends Componen
     return issue?.title ?? 'Unknown issue';
   };
 
+  issueEstimatedHours = (issue: GithubIssueModel | null): number | null => {
+    return issue?.estimatedHours ?? null;
+  };
+
+  issueEstimationConfidence = (
+    issue: GithubIssueModel | null
+  ): 'low' | 'medium' | 'high' | null => {
+    return issue?.estimationConfidence ?? null;
+  };
+
+  selectedIssueEstimateLabel = (issue: SelectedIssue): string => {
+    if (!issue.estimatedHours) {
+      return 'No AI estimate';
+    }
+
+    const confidenceLabel = issue.estimationConfidence
+      ? ` · ${issue.estimationConfidence} confidence`
+      : '';
+
+    return `AI estimate: ${issue.estimatedHours}h${confidenceLabel}`;
+  };
+
+  assignmentEstimateLabel = (issue: GithubIssueModel | null): string | null => {
+    if (!issue?.estimatedHours) {
+      return null;
+    }
+
+    const confidenceLabel = issue.estimationConfidence
+      ? ` · ${issue.estimationConfidence} confidence`
+      : '';
+
+    return `AI estimate: ${issue.estimatedHours}h${confidenceLabel}`;
+  };
+
   issueCardClass = (issueId: number): string => {
     return `capacity-plan-editor__issue-card ${
       this.selectedIssueId === issueId ? '--selected' : ''
@@ -503,7 +541,8 @@ export default class RoutesWorkspacesEditCapacityPlanningEditor extends Componen
       [issueId]: {
         userId,
         assignedHours:
-          this.draftAssignmentsByIssueId[issueId]?.assignedHours ?? '0',
+          this.draftAssignmentsByIssueId[issueId]?.assignedHours ??
+          String(this.issueById(issueId)?.estimatedHours ?? 0),
       },
     };
 
@@ -841,6 +880,9 @@ export default class RoutesWorkspacesEditCapacityPlanningEditor extends Componen
                               {{issue.priority}}
                             </span>
                           </div>
+                          <span class="capacity-plan-editor__estimate">
+                            {{this.selectedIssueEstimateLabel issue}}
+                          </span>
                         </div>
                       </div>
                     </button>
@@ -995,6 +1037,15 @@ export default class RoutesWorkspacesEditCapacityPlanningEditor extends Componen
                                 {{this.issuePriorityLabel assignment.issue}}
                               </span>
                             </div>
+                            {{#if
+                              (this.assignmentEstimateLabel assignment.issue)
+                            }}
+                              <span class="capacity-plan-editor__estimate">
+                                {{this.assignmentEstimateLabel
+                                  assignment.issue
+                                }}
+                              </span>
+                            {{/if}}
                           </div>
                         </div>
 

--- a/client/app/components/routes/workspaces/edit/issues/edit.gts
+++ b/client/app/components/routes/workspaces/edit/issues/edit.gts
@@ -101,6 +101,18 @@ export default class RoutesWorkspacesEditIssuesEdit extends Component<RoutesWork
     return this.args.model.repositoryName ?? 'Unknown repository';
   }
 
+  get estimatedHoursLabel(): string {
+    if (!this.issue.estimatedHours) {
+      return 'No estimate';
+    }
+
+    const confidenceLabel = this.issue.estimationConfidence
+      ? ` · ${this.issue.estimationConfidence} confidence`
+      : '';
+
+    return `${this.issue.estimatedHours}h${confidenceLabel}`;
+  }
+
   get closeRoute(): string {
     return this.args.closeRoute ?? 'workspaces.edit.issues';
   }
@@ -208,6 +220,13 @@ export default class RoutesWorkspacesEditIssuesEdit extends Component<RoutesWork
               <span class="issue-edit-metadata__label">Repository</span>
               <span class="issue-edit-metadata__value">
                 {{this.repositoryName}}
+              </span>
+            </div>
+
+            <div class="issue-edit-metadata__item">
+              <span class="issue-edit-metadata__label">Estimated Effort</span>
+              <span class="issue-edit-metadata__value">
+                {{this.estimatedHoursLabel}}
               </span>
             </div>
 

--- a/client/app/components/routes/workspaces/edit/issues/new.gts
+++ b/client/app/components/routes/workspaces/edit/issues/new.gts
@@ -18,6 +18,8 @@ import UiLoadingSpinner from 'client/components/ui/loading-spinner';
 type AnalyzeIssueResponse = {
   priority: string;
   reason: string;
+  estimatedHours?: number | null;
+  estimationConfidence?: 'low' | 'medium' | 'high' | null;
 };
 
 type CreateIssueResponse = {
@@ -127,6 +129,18 @@ export default class RoutesWorkspacesEditIssuesNew extends Component<RoutesWorks
       default:
         return 'UNKNOWN';
     }
+  }
+
+  get estimatedHoursLabel(): string | null {
+    if (!this.analysisResult?.estimatedHours) {
+      return null;
+    }
+
+    const confidenceLabel = this.analysisResult.estimationConfidence
+      ? ` · ${this.analysisResult.estimationConfidence} confidence`
+      : '';
+
+    return `${this.analysisResult.estimatedHours}h${confidenceLabel}`;
   }
 
   analyzeIssueTask = task(async () => {
@@ -337,6 +351,12 @@ export default class RoutesWorkspacesEditIssuesNew extends Component<RoutesWorks
                 <p class="issue-edit-analysis__content margin-zero">
                   {{this.analysisResult.reason}}
                 </p>
+                {{#if this.estimatedHoursLabel}}
+                  <p class="issue-edit-analysis__content margin-zero">
+                    Estimated effort:
+                    {{this.estimatedHoursLabel}}
+                  </p>
+                {{/if}}
               </:default>
             </UiContainer>
           </div>

--- a/client/app/models/ai-prediction.ts
+++ b/client/app/models/ai-prediction.ts
@@ -17,4 +17,7 @@ export default class AIPredictionModel extends Model {
     username: string;
     reason: string;
   }> | null;
+  @attr('number') declare estimatedHours: number | null;
+  @attr('string')
+  declare estimationConfidence: 'low' | 'medium' | 'high' | null;
 }

--- a/client/app/models/github-issue.ts
+++ b/client/app/models/github-issue.ts
@@ -30,4 +30,12 @@ export default class GithubIssueModel extends Model {
   get priorityReason(): string | null {
     return this.aiPrediction?.reason ?? null;
   }
+
+  get estimatedHours(): number | null {
+    return this.aiPrediction?.estimatedHours ?? null;
+  }
+
+  get estimationConfidence(): 'low' | 'medium' | 'high' | null {
+    return this.aiPrediction?.estimationConfidence ?? null;
+  }
 }

--- a/client/app/styles/routes/workspaces/capacity-planning-new.css
+++ b/client/app/styles/routes/workspaces/capacity-planning-new.css
@@ -150,6 +150,11 @@
     }
   }
 
+  .capacity-plan-editor__estimate {
+    color: var(--text-secondary);
+    font-size: var(--font-size-text-sm);
+  }
+
   .capacity-plan-editor__notes {
     width: 100%;
     min-height: 8rem;


### PR DESCRIPTION
## Summary

- Add AI prediction fields and migration support for estimated issue effort and confidence.
- Let issue-priority predictions use repository context through GitHub repository overview, directory, and file-content helpers.
- Persist effort estimates through issue sync flows and cleanup issue assignments when issues or repositories are deleted.
- Add logging around pull request merge-risk tool usage.

## Validation

- `pnpm vitest run src/__tests__/unit/models/ai-prediction.model.test.ts src/__tests__/unit/services/ai-prediction.service.test.ts src/__tests__/unit/services/issue-priority.service.test.ts src/__tests__/unit/controllers/issue.controller.test.ts src/__tests__/unit/services/github-webhook.service.test.ts src/__tests__/unit/services/issue.service.test.ts`
- `pnpm build`

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Medium
> Reason: This PR introduces database schema changes for AI prediction effort estimates and modifies several core services to handle these new fields. The changes are largely additive and well-tested, but touch critical data models and service logic. Key areas of risk include the new database migration scripts and the synchronization logic in AIPredictionService. However, since the changes are mostly additive and properly tested, the overall risk is moderate.
> Written by `DevTeams`
<!-- onlab-ai-priority:end -->