### PR TITLE
implement rbac authorization with query filtering

### DIFF
--- a/.github/workflows/api-coverage.yaml
+++ b/.github/workflows/api-coverage.yaml
@@ -26,6 +26,11 @@ jobs:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DATABASE: onlab_test
       POSTGRES_URL: postgres://postgres:postgres@localhost:5432/onlab_test
+      TEST_POSTGRES_HOST: localhost
+      TEST_POSTGRES_PORT: 5432
+      TEST_POSTGRES_USER: postgres
+      TEST_POSTGRES_PASSWORD: postgres
+      TEST_POSTGRES_DATABASE: onlab_test
 
     services:
       postgres:
@@ -69,10 +74,6 @@ jobs:
           until pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DATABASE"; do
             sleep 1
           done
-
-      - name: Run API migrations
-        working-directory: api
-        run: pnpm exec db-migrate up --env dev
 
       - name: Run API tests with coverage
         working-directory: api

--- a/api/database.json
+++ b/api/database.json
@@ -17,5 +17,23 @@
     "port": {
       "ENV": "POSTGRES_PORT"
     }
+  },
+  "test": {
+    "driver": "pg",
+    "user": {
+      "ENV": "TEST_POSTGRES_USER"
+    },
+    "host": {
+      "ENV": "TEST_POSTGRES_HOST"
+    },
+    "database": {
+      "ENV": "TEST_POSTGRES_DATABASE"
+    },
+    "password": {
+      "ENV": "TEST_POSTGRES_PASSWORD"
+    },
+    "port": {
+      "ENV": "TEST_POSTGRES_PORT"
+    }
   }
 }

--- a/api/migrations/20260511161000-github-installation-state.js
+++ b/api/migrations/20260511161000-github-installation-state.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options) {
+  Promise = options.Promise;
+};
+
+function runSqlFile(db, fileName) {
+  var filePath = path.join(__dirname, 'sqls', fileName);
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+}
+
+exports.up = function(db) {
+  return runSqlFile(db, '20260511161000-github-installation-state-up.sql');
+};
+
+exports.down = function(db) {
+  return runSqlFile(db, '20260511161000-github-installation-state-down.sql');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/sqls/20260511161000-github-installation-state-down.sql
+++ b/api/migrations/sqls/20260511161000-github-installation-state-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS github.installation_state;

--- a/api/migrations/sqls/20260511161000-github-installation-state-up.sql
+++ b/api/migrations/sqls/20260511161000-github-installation-state-up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS github.installation_state (
+  nonce varchar(128) PRIMARY KEY,
+  workspace_id integer NOT NULL REFERENCES system.workspace(id) ON DELETE CASCADE,
+  user_id integer NOT NULL REFERENCES auth."user"(id) ON DELETE CASCADE,
+  issued_at timestamp with time zone NOT NULL,
+  expires_at timestamp with time zone NOT NULL,
+  consumed_at timestamp with time zone
+);
+
+CREATE INDEX IF NOT EXISTS github_installation_state_lookup_idx
+ON github.installation_state (workspace_id, user_id, expires_at, consumed_at);

--- a/api/package.json
+++ b/api/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@loopback/authentication": "^12.0.11",
     "@loopback/authentication-jwt": "^0.16.11",
+    "@loopback/authorization": "^0.16.12",
     "@loopback/boot": "^8.0.5",
     "@loopback/core": "^7.0.4",
     "@loopback/cron": "^0.13.11",

--- a/api/src/__tests__/global-setup.ts
+++ b/api/src/__tests__/global-setup.ts
@@ -1,0 +1,43 @@
+import {existsSync} from 'fs';
+import path from 'path';
+import {runTestMigrations} from './test-database';
+
+export default async function globalSetup() {
+  if (!shouldRunTestMigrations()) {
+    return;
+  }
+
+  await runTestMigrations();
+}
+
+function shouldRunTestMigrations(): boolean {
+  if (process.env.SKIP_TEST_MIGRATIONS === 'true') {
+    return false;
+  }
+
+  if (process.env.RUN_TEST_MIGRATIONS === 'true') {
+    return true;
+  }
+
+  if (!existsSync(path.resolve(process.cwd(), 'src/__tests__'))) {
+    return false;
+  }
+
+  const testFileFilters = getExplicitTestFilters();
+
+  if (!testFileFilters.length) {
+    return true;
+  }
+
+  return testFileFilters.some(argument => argument.includes('integration'));
+}
+
+function getExplicitTestFilters(): string[] {
+  const runIndex = process.argv.lastIndexOf('run');
+  const candidateArgs =
+    runIndex >= 0 ? process.argv.slice(runIndex + 1) : process.argv.slice(2);
+
+  return candidateArgs.filter(
+    argument => argument.length > 0 && !argument.startsWith('-'),
+  );
+}

--- a/api/src/__tests__/integration/repositories/test-helpers.ts
+++ b/api/src/__tests__/integration/repositories/test-helpers.ts
@@ -9,6 +9,14 @@ import * as repositoryExports from '../../../repositories';
 import {TEST_DATASOURCE_CONFIG} from '../../test-database';
 
 const TEST_SCHEMAS = ['auth', 'system', 'github', 'planning', 'communication'];
+const NOOP_QUEUE_SERVICE = {
+  enqueueGithubIssuesSync: async () => undefined,
+  enqueueGithubLabelsSync: async () => undefined,
+  enqueueGithubIssueCreation: async () => undefined,
+  enqueueGithubPullRequestPrioritization: async () => undefined,
+  enqueueNewsFeedPrediction: async () => undefined,
+  close: async () => undefined,
+};
 
 export const createTestDataSource = () =>
   new PostgresDbDataSource(TEST_DATASOURCE_CONFIG);
@@ -72,6 +80,7 @@ export const setupRepositoryTestApp = async (
   app
     .bind(AuthenticationBindings.CURRENT_USER)
     .toDynamicValue(async () => currentUser);
+  app.bind('services.QueueService').to(NOOP_QUEUE_SERVICE);
   registerRepositories(app);
 
   return {

--- a/api/src/__tests__/integration/repositories/test-helpers.ts
+++ b/api/src/__tests__/integration/repositories/test-helpers.ts
@@ -6,48 +6,41 @@ import {PostgresDbDataSource} from '../../../datasources';
 import {User, Workspace} from '../../../models';
 import {UserRepository, WorkspaceRepository} from '../../../repositories';
 import * as repositoryExports from '../../../repositories';
+import {TEST_DATASOURCE_CONFIG} from '../../test-database';
 
-const TEST_TABLES = [
-  '"system"."ai_prediction"',
-  'github."label"',
-  'github."pull_request"',
-  'github."issue"',
-  'github."repository"',
-  '"system"."file"',
-  '"system"."invitation"',
-  '"system"."workspace_member"',
-  '"system".workspace',
-  'auth.access_token',
-  'auth."user"',
-];
-
-const TEST_POSTGRES_HOST = process.env.POSTGRES_TEST_HOST ?? 'localhost';
-const TEST_POSTGRES_PORT = Number(process.env.POSTGRES_TEST_PORT ?? 5432);
-const TEST_POSTGRES_USER = process.env.POSTGRES_TEST_USER ?? 'postgres';
-const TEST_POSTGRES_PASSWORD = process.env.POSTGRES_TEST_PASSWORD ?? 'postgres';
-const TEST_POSTGRES_DATABASE =
-  process.env.POSTGRES_TEST_DATABASE ?? 'onlab_test';
-
-const TEST_DATASOURCE_CONFIG = {
-  name: 'postgresDB',
-  connector: 'postgresql' as const,
-  url:
-    process.env.POSTGRES_TEST_URL ??
-    `postgres://${TEST_POSTGRES_USER}:${TEST_POSTGRES_PASSWORD}@${TEST_POSTGRES_HOST}:${TEST_POSTGRES_PORT}/${TEST_POSTGRES_DATABASE}`,
-  host: TEST_POSTGRES_HOST,
-  port: TEST_POSTGRES_PORT,
-  user: TEST_POSTGRES_USER,
-  password: TEST_POSTGRES_PASSWORD,
-  database: TEST_POSTGRES_DATABASE,
-  connectionTimeoutMillis: 3000,
-};
+const TEST_SCHEMAS = ['auth', 'system', 'github', 'planning', 'communication'];
 
 export const createTestDataSource = () =>
   new PostgresDbDataSource(TEST_DATASOURCE_CONFIG);
 
 export const resetTestDataSource = async (dataSource: juggler.DataSource) => {
+  const tables = await getTestTableNames(dataSource);
+
+  if (!tables.length) {
+    return;
+  }
+
   await dataSource.execute(
-    `TRUNCATE TABLE ${TEST_TABLES.join(', ')} RESTART IDENTITY CASCADE;`,
+    `TRUNCATE TABLE ${tables.join(', ')} RESTART IDENTITY CASCADE;`,
+  );
+};
+
+const getTestTableNames = async (
+  dataSource: juggler.DataSource,
+): Promise<string[]> => {
+  const rows = await dataSource.execute(
+    `
+      SELECT schemaname, tablename
+      FROM pg_tables
+      WHERE schemaname = ANY($1)
+      ORDER BY schemaname, tablename;
+    `,
+    [TEST_SCHEMAS],
+  );
+
+  return rows.map(
+    (row: {schemaname: string; tablename: string}) =>
+      `"${row.schemaname}"."${row.tablename}"`,
   );
 };
 

--- a/api/src/__tests__/integration/repositories/test-helpers.ts
+++ b/api/src/__tests__/integration/repositories/test-helpers.ts
@@ -1,4 +1,5 @@
 import {AuthenticationBindings} from '@loopback/authentication';
+import {asService} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 import {securityId, UserProfile} from '@loopback/security';
 import {RestApi} from '../../..';
@@ -6,6 +7,7 @@ import {PostgresDbDataSource} from '../../../datasources';
 import {User, Workspace} from '../../../models';
 import {UserRepository, WorkspaceRepository} from '../../../repositories';
 import * as repositoryExports from '../../../repositories';
+import {QueueService} from '../../../services/queue.service';
 import {TEST_DATASOURCE_CONFIG} from '../../test-database';
 
 const TEST_SCHEMAS = ['auth', 'system', 'github', 'planning', 'communication'];
@@ -80,7 +82,10 @@ export const setupRepositoryTestApp = async (
   app
     .bind(AuthenticationBindings.CURRENT_USER)
     .toDynamicValue(async () => currentUser);
-  app.bind('services.QueueService').to(NOOP_QUEUE_SERVICE);
+  app
+    .bind('services.QueueService')
+    .to(NOOP_QUEUE_SERVICE)
+    .apply(asService(QueueService));
   registerRepositories(app);
 
   return {

--- a/api/src/__tests__/test-database.ts
+++ b/api/src/__tests__/test-database.ts
@@ -1,0 +1,95 @@
+import {execFile} from 'child_process';
+import path from 'path';
+import {promisify} from 'util';
+
+const API_ROOT = path.resolve(__dirname, '../..');
+
+const TEST_POSTGRES_HOST =
+  process.env.TEST_POSTGRES_HOST ??
+  process.env.POSTGRES_TEST_HOST ??
+  process.env.POSTGRES_HOST ??
+  'localhost';
+const TEST_POSTGRES_PORT = Number(
+  process.env.TEST_POSTGRES_PORT ??
+    process.env.POSTGRES_TEST_PORT ??
+    process.env.POSTGRES_PORT ??
+    5432,
+);
+const TEST_POSTGRES_USER =
+  process.env.TEST_POSTGRES_USER ??
+  process.env.POSTGRES_TEST_USER ??
+  process.env.POSTGRES_USER ??
+  'postgres';
+const TEST_POSTGRES_PASSWORD =
+  process.env.TEST_POSTGRES_PASSWORD ??
+  process.env.POSTGRES_TEST_PASSWORD ??
+  process.env.POSTGRES_PASSWORD ??
+  'postgres';
+const TEST_POSTGRES_DATABASE =
+  process.env.TEST_POSTGRES_DATABASE ??
+  process.env.POSTGRES_TEST_DATABASE ??
+  getDefaultTestDatabase() ??
+  'onlab_test';
+
+export const TEST_DATASOURCE_CONFIG = {
+  name: 'postgresDB',
+  connector: 'postgresql' as const,
+  url:
+    process.env.TEST_POSTGRES_URL ??
+    process.env.POSTGRES_TEST_URL ??
+    `postgres://${TEST_POSTGRES_USER}:${TEST_POSTGRES_PASSWORD}@${TEST_POSTGRES_HOST}:${TEST_POSTGRES_PORT}/${TEST_POSTGRES_DATABASE}`,
+  host: TEST_POSTGRES_HOST,
+  port: TEST_POSTGRES_PORT,
+  user: TEST_POSTGRES_USER,
+  password: TEST_POSTGRES_PASSWORD,
+  database: TEST_POSTGRES_DATABASE,
+  connectionTimeoutMillis: 3000,
+};
+
+const execFileAsync = promisify(execFile);
+let migrationsPromise: Promise<void> | undefined;
+
+function getDefaultTestDatabase(): string | undefined {
+  if (!process.env.POSTGRES_DATABASE) {
+    return undefined;
+  }
+
+  return `${process.env.POSTGRES_DATABASE.replace(/_?test$/i, '')}_test`;
+}
+
+export const runTestMigrations = async () => {
+  migrationsPromise ??= runMigrations();
+  await migrationsPromise;
+};
+
+const runMigrations = async () => {
+  try {
+    const {stdout, stderr} = await execFileAsync(
+      process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+      ['exec', 'db-migrate', 'up', '--env', 'test'],
+      {
+        cwd: API_ROOT,
+        env: {
+          ...process.env,
+          TEST_POSTGRES_HOST,
+          TEST_POSTGRES_PORT: String(TEST_POSTGRES_PORT),
+          TEST_POSTGRES_USER,
+          TEST_POSTGRES_PASSWORD,
+          TEST_POSTGRES_DATABASE,
+        },
+      },
+    );
+
+    if (stdout) {
+      console.log(stdout);
+    }
+
+    if (stderr) {
+      console.error(stderr);
+    }
+  } catch (error) {
+    console.error('Migration failed:', error);
+
+    throw error;
+  }
+};

--- a/api/src/__tests__/unit/authorization/workspace-authorizer.provider.test.ts
+++ b/api/src/__tests__/unit/authorization/workspace-authorizer.provider.test.ts
@@ -1,0 +1,80 @@
+import {
+  AuthorizationDecision,
+  type AuthorizationContext,
+  type AuthorizationMetadata,
+} from '@loopback/authorization';
+import {describe, expect, it, vi} from 'vitest';
+
+import {WorkspaceAuthorizerProvider} from '../../../authorization/workspace-authorizer.provider';
+import {WORKSPACE_PERMISSION} from '../../../constants';
+
+describe('WorkspaceAuthorizerProvider (unit)', () => {
+  const createProvider = () => {
+    const service = {
+      checkPermission: vi.fn().mockResolvedValue({allowed: true}),
+    };
+    const provider = new WorkspaceAuthorizerProvider(service as never);
+
+    return {
+      service,
+      provider,
+    };
+  };
+
+  const createContext = (
+    args: unknown[],
+    principal: {id?: unknown; [key: string]: unknown} = {id: 7},
+  ): AuthorizationContext =>
+    ({
+      principals: [principal],
+      invocationContext: {args},
+    }) as AuthorizationContext;
+
+  it('abstains for metadata without a known workspace permission', async () => {
+    const {provider, service} = createProvider();
+
+    await expect(
+      provider.authorize(createContext([3]), {
+        resource: 'unknown.permission',
+      } as AuthorizationMetadata),
+    ).resolves.toBe(AuthorizationDecision.ABSTAIN);
+    expect(service.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it('denies when user id or workspace id cannot be resolved', async () => {
+    const {provider, service} = createProvider();
+
+    await expect(
+      provider.authorize(createContext([{other: 3}], {id: 'not-a-number'}), {
+        resource: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      } as AuthorizationMetadata),
+    ).resolves.toBe(AuthorizationDecision.DENY);
+    expect(service.checkPermission).not.toHaveBeenCalled();
+  });
+
+  it('allows when the authorization service allows the permission', async () => {
+    const {provider, service} = createProvider();
+
+    await expect(
+      provider.authorize(createContext([{workspaceId: '3'}]), {
+        resource: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      } as AuthorizationMetadata),
+    ).resolves.toBe(AuthorizationDecision.ALLOW);
+    expect(service.checkPermission).toHaveBeenCalledWith(
+      3,
+      7,
+      WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+    );
+  });
+
+  it('denies when the authorization service denies the permission', async () => {
+    const {provider, service} = createProvider();
+    service.checkPermission.mockResolvedValue({allowed: false});
+
+    await expect(
+      provider.authorize(createContext(['3']), {
+        resource: WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+      } as AuthorizationMetadata),
+    ).resolves.toBe(AuthorizationDecision.DENY);
+  });
+});

--- a/api/src/__tests__/unit/controllers/authorization.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/authorization.controller.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {AuthorizationController} from '../../../controllers/system/authorization.controller';
+import {WORKSPACE_PERMISSION} from '../../../constants';
+
+describe('AuthorizationController (unit)', () => {
+  it('returns backend permission decisions for route guards', async () => {
+    const service = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      checkPermission: vi.fn().mockResolvedValue({
+        allowed: true,
+        permission: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+        workspaceId: 3,
+        role: 'MEMBER',
+      }),
+    };
+    const controller = new AuthorizationController(service as never);
+
+    await expect(
+      controller.check({id: 7} as never, {
+        workspaceId: 3,
+        permission: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      permission: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      workspaceId: 3,
+      role: 'MEMBER',
+    });
+
+    expect(service.checkPermission).toHaveBeenCalledWith(
+      3,
+      7,
+      WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+    );
+  });
+
+  it('denies unknown permissions without delegating', async () => {
+    const service = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      checkPermission: vi.fn(),
+    };
+    const controller = new AuthorizationController(service as never);
+
+    await expect(
+      controller.check({id: 7} as never, {
+        workspaceId: 3,
+        permission: 'workspace.unknown' as never,
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      permission: 'workspace.unknown',
+      workspaceId: 3,
+      role: null,
+    });
+
+    expect(service.checkPermission).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/__tests__/unit/controllers/file.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/file.controller.test.ts
@@ -2,16 +2,70 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {File} from '../../../models';
 import {FileController} from '../../../controllers/system/file.controller';
-import {createCrudRepositoryMock, describeCrudController} from './test-helpers';
 
 describe('FileController (unit)', () => {
-  describeCrudController({
-    controllerName: 'FileController',
-    createController: repository => new FileController(repository as never),
-    id: 31,
-    filter: {where: {workspaceId: 11}},
-    where: {workspaceId: 11},
-    entityFactory: () =>
+  let repository: {
+    find: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+    upload: ReturnType<typeof vi.fn>;
+    download: ReturnType<typeof vi.fn>;
+    preview: ReturnType<typeof vi.fn>;
+  };
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    accessibleWorkspaceIds: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+  };
+  let controller: FileController;
+
+  beforeEach(() => {
+    repository = {
+      find: vi.fn(),
+      count: vi.fn(),
+      findById: vi.fn(),
+      upload: vi.fn(),
+      download: vi.fn(),
+      preview: vi.fn(),
+    };
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([11]),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+    };
+    controller = new FileController(
+      repository as never,
+      authorization as never,
+    );
+  });
+
+  it('scopes file queries to accessible workspaces', async () => {
+    const file = new File({
+      id: 31,
+      workspaceId: 11,
+      originalName: 'avatar.png',
+      mimeType: 'image/png',
+      size: 2048,
+      path: '/uploads/avatar.png',
+    });
+    repository.find.mockResolvedValue([file]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {mimeType: 'image/png'}}),
+    ).resolves.toEqual([file]);
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{mimeType: 'image/png'}, {workspaceId: {inq: [11]}}],
+      },
+    });
+  });
+
+  it('checks workspace membership before upload and streaming', async () => {
+    const request = {query: {workspaceId: '11'}};
+    const response = {status: vi.fn()};
+    const uploadResult = {id: 31, url: '/files/31/preview'};
+    repository.upload.mockResolvedValue(uploadResult);
+    repository.findById.mockResolvedValue(
       new File({
         id: 31,
         workspaceId: 11,
@@ -20,69 +74,23 @@ describe('FileController (unit)', () => {
         size: 2048,
         path: '/uploads/avatar.png',
       }),
-    createPayloadFactory: () => ({
-      workspaceId: 11,
-      originalName: 'avatar.png',
-      mimeType: 'image/png',
-      size: 2048,
-      path: '/uploads/avatar.png',
-    }),
-    updatePayloadFactory: () => ({
-      originalName: 'avatar-updated.png',
-    }),
-    relationName: 'workspace',
-    relationValueFactory: () => ({
-      id: 11,
-      name: 'Demo Workspace',
-    }),
-  });
-
-  let repository: ReturnType<typeof createCrudRepositoryMock> & {
-    upload: ReturnType<typeof vi.fn>;
-    download: ReturnType<typeof vi.fn>;
-    preview: ReturnType<typeof vi.fn>;
-  };
-  let controller: FileController;
-
-  beforeEach(() => {
-    repository = {
-      ...createCrudRepositoryMock(),
-      upload: vi.fn(),
-      download: vi.fn(),
-      preview: vi.fn(),
-    };
-    controller = new FileController(repository as never);
-  });
-
-  it('uploads files', async () => {
-    const request = {file: {originalname: 'avatar.png'}};
-    const response = {status: vi.fn()};
-    const uploadResult = {id: 31, url: '/files/31/preview'};
-    repository.upload.mockResolvedValue(uploadResult);
-
-    await expect(
-      controller.upload(request as never, response as never),
-    ).resolves.toEqual(uploadResult);
-    expect(repository.upload).toHaveBeenCalledWith(request, response);
-  });
-
-  it('downloads files by id', async () => {
-    const response = {download: vi.fn()};
-    repository.download.mockResolvedValue(response);
-
-    await expect(controller.download(31, response as never)).resolves.toEqual(
-      response,
     );
-    expect(repository.download).toHaveBeenCalledWith(31, response);
-  });
-
-  it('previews files by id', async () => {
-    const response = {sendFile: vi.fn()};
+    repository.download.mockResolvedValue(response);
     repository.preview.mockResolvedValue(response);
 
-    await expect(controller.preview(31, response as never)).resolves.toEqual(
-      response,
-    );
+    await expect(
+      controller.upload({id: 7} as never, request as never, response as never),
+    ).resolves.toEqual(uploadResult);
+    await expect(
+      controller.download({id: 7} as never, 31, response as never),
+    ).resolves.toEqual(response);
+    await expect(
+      controller.preview({id: 7} as never, 31, response as never),
+    ).resolves.toEqual(response);
+
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(11, 7);
+    expect(repository.upload).toHaveBeenCalledWith(request, response);
+    expect(repository.download).toHaveBeenCalledWith(31, response);
     expect(repository.preview).toHaveBeenCalledWith(31, response);
   });
 });

--- a/api/src/__tests__/unit/controllers/github.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/github.controller.test.ts
@@ -1,0 +1,81 @@
+import {HttpErrors} from '@loopback/rest';
+import {describe, expect, it, vi} from 'vitest';
+
+import {GithubController} from '../../../controllers/github-integration/github.controller';
+import {WORKSPACE_PERMISSION} from '../../../constants';
+
+describe('GithubController (unit)', () => {
+  it('requires workspace install permission before redirecting to GitHub', async () => {
+    const githubService = {
+      getInstallationUrl: vi
+        .fn()
+        .mockResolvedValue(
+          'https://github.com/apps/devteams/installations/new',
+        ),
+      callback: vi.fn(),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      assertPermission: vi.fn().mockResolvedValue('ADMIN'),
+    };
+    const response = {
+      redirect: vi.fn(),
+    };
+    const controller = new GithubController(
+      githubService as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.installGithubApp({id: 7} as never, response as never, '42'),
+    ).resolves.toBeUndefined();
+
+    expect(authorization.assertPermission).toHaveBeenCalledWith(
+      42,
+      7,
+      WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE,
+    );
+    expect(githubService.getInstallationUrl).toHaveBeenCalledWith({
+      workspaceId: 42,
+      userId: 7,
+    });
+    expect(response.redirect).toHaveBeenCalledWith(
+      'https://github.com/apps/devteams/installations/new',
+    );
+  });
+
+  it('rejects install requests without a workspace id', async () => {
+    const controller = new GithubController({} as never, {} as never);
+
+    await expect(
+      controller.installGithubApp({id: 7} as never, {} as never),
+    ).rejects.toBeInstanceOf(HttpErrors.BadRequest);
+  });
+
+  it('delegates callback handling to the GitHub service', async () => {
+    const githubService = {
+      callback: vi.fn().mockResolvedValue({redirected: true}),
+    };
+    const controller = new GithubController(
+      githubService as never,
+      {} as never,
+    );
+    const response = {redirect: vi.fn()};
+
+    await expect(
+      controller.githubCallback(
+        response as never,
+        '77',
+        'install',
+        'signed-state',
+      ),
+    ).resolves.toEqual({redirected: true});
+
+    expect(githubService.callback).toHaveBeenCalledWith(
+      response,
+      '77',
+      'install',
+      'signed-state',
+    );
+  });
+});

--- a/api/src/__tests__/unit/controllers/invitation.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/invitation.controller.test.ts
@@ -1,48 +1,80 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {Invitation} from '../../../models';
 import {InvitationController} from '../../../controllers/system/invitation.controller';
-import {createCrudRepositoryMock, describeCrudController} from './test-helpers';
+import {Invitation} from '../../../models';
 
 describe('InvitationController (unit)', () => {
-  describeCrudController({
-    controllerName: 'InvitationController',
-    createController: repository =>
-      new InvitationController(repository as never),
-    id: 23,
-    filter: {where: {email: 'aron@example.com'}},
-    where: {workspaceId: 11},
-    entityFactory: () =>
-      new Invitation({
-        id: 23,
-        email: 'aron@example.com',
-        workspaceId: 11,
-      }),
-    createPayloadFactory: () => ({
-      email: 'aron@example.com',
-      workspaceId: 11,
-    }),
-    updatePayloadFactory: () => ({
-      email: 'updated@example.com',
-    }),
-    relationName: 'workspace',
-    relationValueFactory: () => ({
-      id: 11,
-      name: 'Demo Workspace',
-    }),
-  });
-
-  let repository: ReturnType<typeof createCrudRepositoryMock> & {
+  let repository: {
+    find: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
     accept: ReturnType<typeof vi.fn>;
+  };
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    accessibleWorkspaceIds: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+    assertWorkspaceAdminOrOwner: ReturnType<typeof vi.fn>;
   };
   let controller: InvitationController;
 
   beforeEach(() => {
     repository = {
-      ...createCrudRepositoryMock(),
+      find: vi.fn(),
+      findById: vi.fn(),
+      create: vi.fn(),
       accept: vi.fn(),
     };
-    controller = new InvitationController(repository as never);
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([11]),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+      assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
+    };
+    controller = new InvitationController(
+      repository as never,
+      authorization as never,
+    );
+  });
+
+  it('scopes invitation lists to accessible workspaces', async () => {
+    const invitation = new Invitation({
+      id: 23,
+      email: 'aron@example.com',
+      workspaceId: 11,
+    });
+    repository.find.mockResolvedValue([invitation]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {email: 'aron@example.com'}}),
+    ).resolves.toEqual([invitation]);
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{email: 'aron@example.com'}, {workspaceId: {inq: [11]}}],
+      },
+    });
+  });
+
+  it('requires admin or owner permission when creating invitations', async () => {
+    const invitation = new Invitation({
+      id: 23,
+      email: 'aron@example.com',
+      workspaceId: 11,
+    });
+    repository.create.mockResolvedValue(invitation);
+
+    await expect(
+      controller.create({id: 7} as never, {
+        email: 'aron@example.com',
+        workspaceId: 11,
+      }),
+    ).resolves.toBe(invitation);
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      11,
+      7,
+    );
   });
 
   it('accepts invitations by id', async () => {

--- a/api/src/__tests__/unit/controllers/issue.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/issue.controller.test.ts
@@ -1,74 +1,123 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {GithubIssueController} from '../../../controllers/github/issue.controller';
+import {GithubIssue} from '../../../models';
+import type {IssuePriorityPrediction} from '../../../services';
 
 describe('GithubIssueController (unit)', () => {
-  let githubIssueRepository: object;
-  let issueService: {
-    deleteById: ReturnType<typeof vi.fn>;
-    deleteAll: ReturnType<typeof vi.fn>;
+  let issueRepository: {
+    find: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  let repositoryRepository: {
+    find: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  let workspaceRepository: {findById: ReturnType<typeof vi.fn>};
+  let issueService: {deleteById: ReturnType<typeof vi.fn>};
+  let priorityService: {
+    predictIssuePriority: ReturnType<typeof vi.fn>;
+    normalizePredictionInput: ReturnType<typeof vi.fn>;
+  };
+  let queueService: {enqueueGithubIssueCreation: ReturnType<typeof vi.fn>};
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    accessibleWorkspaceIds: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+    assertWorkspaceAdminOrOwner: ReturnType<typeof vi.fn>;
   };
   let controller: GithubIssueController;
 
   beforeEach(() => {
-    githubIssueRepository = {};
+    issueRepository = {
+      find: vi.fn(),
+      findById: vi.fn(),
+    };
+    repositoryRepository = {
+      find: vi.fn().mockResolvedValue([{id: 4, workspaceId: 9}]),
+      findById: vi
+        .fn()
+        .mockResolvedValue({id: 4, workspaceId: 9, fullName: 'team/api'}),
+    };
+    workspaceRepository = {
+      findById: vi.fn().mockResolvedValue({githubInstallationId: 11}),
+    };
     issueService = {
       deleteById: vi.fn().mockResolvedValue(undefined),
-      deleteAll: vi.fn().mockResolvedValue({count: 2}),
     };
-
-    controller = new GithubIssueController(
-      githubIssueRepository as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      issueService as never,
-      {} as never,
-    );
-  });
-
-  it('deletes a single issue through IssueService', async () => {
-    await expect(controller.deleteById(7)).resolves.toBeUndefined();
-    expect(issueService.deleteById).toHaveBeenCalledWith(7);
-  });
-
-  it('deletes matching issues through IssueService', async () => {
-    const where = {repositoryId: 3} as never;
-
-    await expect(controller.deleteAll(where)).resolves.toEqual({count: 2});
-    expect(issueService.deleteAll).toHaveBeenCalledWith(where);
-  });
-
-  it('still supports priority analysis for issue drafts', async () => {
-    const priorityService = {
+    priorityService = {
       predictIssuePriority: vi.fn().mockResolvedValue({
         priority: 'High',
         reason: 'Blocks the release',
         estimatedHours: 8,
         estimationConfidence: 'medium',
       }),
+      normalizePredictionInput: vi.fn().mockImplementation(prediction =>
+        prediction
+          ? {
+              priority: prediction.priority,
+              reason: prediction.reason,
+              estimatedHours: prediction.estimatedHours ?? null,
+              estimationConfidence: prediction.estimationConfidence ?? null,
+            }
+          : null,
+      ),
     };
-    const repositoryRepository = {
-      findById: vi
-        .fn()
-        .mockResolvedValue({workspaceId: 9, fullName: 'team/api'}),
+    queueService = {
+      enqueueGithubIssueCreation: vi.fn().mockResolvedValue(undefined),
     };
-    const workspaceRepository = {
-      findById: vi.fn().mockResolvedValue({githubInstallationId: 11}),
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([9]),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+      assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
     };
-    const controllerWithDeps = new GithubIssueController(
-      githubIssueRepository as never,
+
+    controller = new GithubIssueController(
+      issueRepository as never,
       repositoryRepository as never,
       workspaceRepository as never,
       {} as never,
       priorityService as never,
       issueService as never,
-      {} as never,
+      queueService as never,
+      authorization as never,
+    );
+  });
+
+  it('scopes issue lists to repositories in accessible workspaces', async () => {
+    const issue = new GithubIssue({id: 7, repositoryId: 4, title: 'Bug'});
+    issueRepository.find.mockResolvedValue([issue]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {status: 'open'}}),
+    ).resolves.toEqual([issue]);
+
+    expect(issueRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{status: 'open'}, {repositoryId: {inq: [4]}}],
+      },
+    });
+  });
+
+  it('deletes a single issue through IssueService after admin check', async () => {
+    issueRepository.findById.mockResolvedValue(
+      new GithubIssue({id: 7, repositoryId: 4}),
     );
 
     await expect(
-      controllerWithDeps.analyzePriority({
+      controller.deleteById({id: 7} as never, 7),
+    ).resolves.toBeUndefined();
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      9,
+      7,
+    );
+    expect(issueService.deleteById).toHaveBeenCalledWith(7);
+  });
+
+  it('supports priority analysis for issue drafts', async () => {
+    await expect(
+      controller.analyzePriority({id: 7} as never, {
         repositoryId: 4,
         title: 'Broken sign-in',
         description: 'Users cannot log in',
@@ -84,6 +133,34 @@ describe('GithubIssueController (unit)', () => {
       repositoryFullName: 'team/api',
       title: 'Broken sign-in',
       description: 'Users cannot log in',
+    });
+  });
+
+  it('queues issue creation with the already analyzed prediction', async () => {
+    const prediction: IssuePriorityPrediction = {
+      priority: 'High',
+      reason: 'Blocks the release',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
+    };
+
+    await expect(
+      controller.createWithPriority({id: 7} as never, {
+        repositoryId: 4,
+        title: 'Broken sign-in',
+        description: 'Users cannot log in',
+        prediction,
+      }),
+    ).resolves.toEqual({queued: true});
+
+    expect(priorityService.normalizePredictionInput).toHaveBeenCalledWith(
+      prediction,
+    );
+    expect(queueService.enqueueGithubIssueCreation).toHaveBeenCalledWith({
+      repositoryId: 4,
+      title: 'Broken sign-in',
+      description: 'Users cannot log in',
+      prediction,
     });
   });
 });

--- a/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
@@ -8,7 +8,13 @@ describe('NewsFeedEntryController (unit)', () => {
   describeCrudController({
     controllerName: 'NewsFeedEntryController',
     createController: repository =>
-      new NewsFeedEntryController(repository as never),
+      new NewsFeedEntryController(
+        repository as never,
+        {
+          getAuthenticatedUserId: vi.fn().mockReturnValue(9),
+          assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+        } as never,
+      ),
     id: 14,
     filter: {where: {workspaceId: 3}},
     where: {workspaceId: 3},
@@ -42,13 +48,24 @@ describe('NewsFeedEntryController (unit)', () => {
   let repository: {
     findPersonalizedFeed: ReturnType<typeof vi.fn>;
   };
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+  };
   let controller: NewsFeedEntryController;
 
   beforeEach(() => {
     repository = {
       findPersonalizedFeed: vi.fn(),
     };
-    controller = new NewsFeedEntryController(repository as never);
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(9),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+    };
+    controller = new NewsFeedEntryController(
+      repository as never,
+      authorization as never,
+    );
   });
 
   it('returns the personalized feed for a workspace and user', async () => {
@@ -66,7 +83,10 @@ describe('NewsFeedEntryController (unit)', () => {
     ];
     repository.findPersonalizedFeed.mockResolvedValue(entries);
 
-    await expect(controller.feed(3, 9)).resolves.toEqual(entries);
+    await expect(controller.feed({id: 9} as never, 3)).resolves.toEqual(
+      entries,
+    );
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 9);
     expect(repository.findPersonalizedFeed).toHaveBeenCalledWith(3, 9);
   });
 });

--- a/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
@@ -2,25 +2,112 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {NewsFeedEntryController} from '../../../controllers';
 import {NewsFeedEntry} from '../../../models';
-import {describeCrudController} from './test-helpers';
 
 describe('NewsFeedEntryController (unit)', () => {
-  describeCrudController({
-    controllerName: 'NewsFeedEntryController',
-    createController: repository =>
-      new NewsFeedEntryController(
-        repository as never,
-        {
-          getAuthenticatedUserId: vi.fn().mockReturnValue(9),
-          assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
-        } as never,
-      ),
-    id: 14,
-    filter: {where: {workspaceId: 3}},
-    where: {workspaceId: 3},
-    entityFactory: () =>
-      new NewsFeedEntry({
-        id: 14,
+  let repository: {
+    find: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    updateById: ReturnType<typeof vi.fn>;
+    replaceById: ReturnType<typeof vi.fn>;
+    deleteById: ReturnType<typeof vi.fn>;
+    findPersonalizedFeed: ReturnType<typeof vi.fn>;
+  };
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    accessibleWorkspaceIds: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+    assertWorkspaceAdminOrOwner: ReturnType<typeof vi.fn>;
+  };
+  let controller: NewsFeedEntryController;
+
+  beforeEach(() => {
+    repository = {
+      find: vi.fn(),
+      count: vi.fn(),
+      findById: vi.fn(),
+      create: vi.fn(),
+      updateById: vi.fn(),
+      replaceById: vi.fn(),
+      deleteById: vi.fn(),
+      findPersonalizedFeed: vi.fn(),
+    };
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(9),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([3, 4]),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+      assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
+    };
+    controller = new NewsFeedEntryController(
+      repository as never,
+      authorization as never,
+    );
+  });
+
+  const entry = new NewsFeedEntry({
+    id: 20,
+    workspaceId: 3,
+    sourceType: 'github-pull-request',
+    sourceId: 31,
+    eventAction: 'updated',
+    title: 'PR updated',
+    summary: 'PR updated',
+    happenedAt: '2026-04-16T09:00:00.000Z',
+  });
+
+  it('scopes list queries to accessible workspaces', async () => {
+    repository.find.mockResolvedValue([entry]);
+
+    await expect(
+      controller.find({id: 9} as never, {where: {workspaceId: 999}}),
+    ).resolves.toEqual([entry]);
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{workspaceId: 999}, {workspaceId: {inq: [3, 4]}}],
+      },
+    });
+  });
+
+  it('scopes count queries to accessible workspaces', async () => {
+    repository.count.mockResolvedValue({count: 1});
+
+    await expect(
+      controller.count({id: 9} as never, {workspaceId: 999}),
+    ).resolves.toEqual({count: 1});
+
+    expect(repository.count).toHaveBeenCalledWith({
+      and: [{workspaceId: 999}, {workspaceId: {inq: [3, 4]}}],
+    });
+  });
+
+  it('returns the personalized feed for the authenticated user', async () => {
+    repository.findPersonalizedFeed.mockResolvedValue([entry]);
+
+    await expect(controller.feed({id: 9} as never, 3)).resolves.toEqual([
+      entry,
+    ]);
+
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 9);
+    expect(repository.findPersonalizedFeed).toHaveBeenCalledWith(3, 9);
+  });
+
+  it('requires workspace membership before returning a single entry', async () => {
+    repository.findById.mockResolvedValue(entry);
+
+    await expect(controller.findById({id: 9} as never, 20)).resolves.toEqual(
+      entry,
+    );
+
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 9);
+  });
+
+  it('requires admin or owner permission before creating entries', async () => {
+    repository.create.mockResolvedValue(entry);
+
+    await expect(
+      controller.create({id: 9} as never, {
         workspaceId: 3,
         sourceType: 'github-issue',
         sourceId: 21,
@@ -29,64 +116,44 @@ describe('NewsFeedEntryController (unit)', () => {
         summary: 'Broken auth',
         happenedAt: '2026-04-16T09:00:00.000Z',
       }),
-    createPayloadFactory: () => ({
-      workspaceId: 3,
-      sourceType: 'github-issue',
-      sourceId: 21,
-      eventAction: 'created',
-      title: 'Broken auth',
-      summary: 'Broken auth',
-      happenedAt: '2026-04-16T09:00:00.000Z',
-    }),
-    updatePayloadFactory: () => ({
-      summary: 'Updated summary',
-    }),
-    relationName: 'expertiseAssocs',
-    relationValueFactory: () => [{id: 5, expertiseId: 6}],
+    ).resolves.toEqual(entry);
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      9,
+    );
+    expect(repository.create).toHaveBeenCalled();
   });
 
-  let repository: {
-    findPersonalizedFeed: ReturnType<typeof vi.fn>;
-  };
-  let authorization: {
-    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
-    assertWorkspaceMember: ReturnType<typeof vi.fn>;
-  };
-  let controller: NewsFeedEntryController;
+  it('requires admin or owner permission before updating entries', async () => {
+    repository.findById.mockResolvedValue(entry);
+    repository.updateById.mockResolvedValue(undefined);
 
-  beforeEach(() => {
-    repository = {
-      findPersonalizedFeed: vi.fn(),
-    };
-    authorization = {
-      getAuthenticatedUserId: vi.fn().mockReturnValue(9),
-      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
-    };
-    controller = new NewsFeedEntryController(
-      repository as never,
-      authorization as never,
+    await expect(
+      controller.updateById({id: 9} as never, 20, {summary: 'Updated'}),
+    ).resolves.toBeUndefined();
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      9,
     );
+    expect(repository.updateById).toHaveBeenCalledWith(20, {
+      summary: 'Updated',
+    });
   });
 
-  it('returns the personalized feed for a workspace and user', async () => {
-    const entries = [
-      new NewsFeedEntry({
-        id: 20,
-        workspaceId: 3,
-        sourceType: 'github-pull-request',
-        sourceId: 31,
-        eventAction: 'updated',
-        title: 'PR updated',
-        summary: 'PR updated',
-        happenedAt: '2026-04-16T09:00:00.000Z',
-      }),
-    ];
-    repository.findPersonalizedFeed.mockResolvedValue(entries);
+  it('requires admin or owner permission before deleting entries', async () => {
+    repository.findById.mockResolvedValue(entry);
+    repository.deleteById.mockResolvedValue(undefined);
 
-    await expect(controller.feed({id: 9} as never, 3)).resolves.toEqual(
-      entries,
+    await expect(
+      controller.deleteById({id: 9} as never, 20),
+    ).resolves.toBeUndefined();
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      9,
     );
-    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 9);
-    expect(repository.findPersonalizedFeed).toHaveBeenCalledWith(3, 9);
+    expect(repository.deleteById).toHaveBeenCalledWith(20);
   });
 });

--- a/api/src/__tests__/unit/controllers/planning.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/planning.controller.test.ts
@@ -10,137 +10,129 @@ import {
   CapacityPlanEntry,
   IssueAssignment,
 } from '../../../models';
-import {describeCrudController} from './test-helpers';
+
+const createAuthorization = () => ({
+  getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+  accessibleWorkspaceIds: vi.fn().mockResolvedValue([3]),
+  assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+  assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
+});
 
 describe('Planning controllers (unit)', () => {
-  describeCrudController({
-    controllerName: 'CapacityPlanController',
-    createController: repository =>
-      new CapacityPlanController(repository as never),
-    id: 8,
-    filter: {where: {workspaceId: 3}},
-    where: {workspaceId: 3},
-    entityFactory: () =>
-      new CapacityPlan({
-        id: 8,
-        workspaceId: 3,
-        start: '2026-04-13T08:00:00.000Z',
-        end: '2026-04-17T17:00:00.000Z',
-      }),
-    createPayloadFactory: () => ({
+  it('scopes capacity plan lists to accessible workspaces', async () => {
+    const repository = {
+      find: vi.fn().mockResolvedValue([
+        new CapacityPlan({
+          id: 8,
+          workspaceId: 3,
+          start: '2026-04-13T08:00:00.000Z',
+          end: '2026-04-17T17:00:00.000Z',
+        }),
+      ]),
+    };
+    const controller = new CapacityPlanController(
+      repository as never,
+      createAuthorization() as never,
+    );
+
+    await controller.find({id: 7} as never, {where: {workspaceId: 3}});
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{workspaceId: 3}, {workspaceId: {inq: [3]}}],
+      },
+    });
+  });
+
+  it('requires admin or owner permission when creating capacity plans', async () => {
+    const repository = {
+      create: vi.fn().mockResolvedValue(new CapacityPlan({id: 8})),
+    };
+    const authorization = createAuthorization();
+    const controller = new CapacityPlanController(
+      repository as never,
+      authorization as never,
+    );
+
+    await controller.create({id: 7} as never, {
       workspaceId: 3,
       start: '2026-04-13T08:00:00.000Z',
       end: '2026-04-17T17:00:00.000Z',
-    }),
-    updatePayloadFactory: () => ({
-      end: '2026-04-18T12:00:00.000Z',
-    }),
-    relationName: 'workspace',
-    relationValueFactory: () => ({
-      id: 3,
-      name: 'Delivery',
-    }),
+    });
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
   });
 
-  describeCrudController({
-    controllerName: 'CapacityPlanEntryController',
-    createController: repository =>
-      new CapacityPlanEntryController(repository as never),
-    id: 4,
-    filter: {where: {capacityPlanId: 8}},
-    where: {capacityPlanId: 8},
-    entityFactory: () =>
-      new CapacityPlanEntry({
-        id: 4,
-        capacityPlanId: 8,
-        userId: 5,
-        capacityHours: 24,
-      }),
-    createPayloadFactory: () => ({
-      capacityPlanId: 8,
+  it('scopes capacity plan entries through accessible capacity plans', async () => {
+    const entryRepository = {
+      find: vi.fn().mockResolvedValue([
+        new CapacityPlanEntry({
+          id: 4,
+          capacityPlanId: 8,
+          userId: 5,
+          capacityHours: 24,
+        }),
+      ]),
+    };
+    const capacityPlanRepository = {
+      find: vi.fn().mockResolvedValue([new CapacityPlan({id: 8})]),
+    };
+    const controller = new CapacityPlanEntryController(
+      entryRepository as never,
+      capacityPlanRepository as never,
+      createAuthorization() as never,
+    );
+
+    await controller.find({id: 7} as never, {where: {userId: 5}});
+
+    expect(entryRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{userId: 5}, {capacityPlanId: {inq: [8]}}],
+      },
+    });
+  });
+
+  it('syncs issue assignments after authorized creation', async () => {
+    const assignment = new IssueAssignment({
+      id: 9,
+      issueId: 11,
       userId: 5,
-      capacityHours: 24,
-    }),
-    updatePayloadFactory: () => ({
-      capacityHours: 20,
-    }),
-    relationName: 'user',
-    relationValueFactory: () => ({
-      id: 5,
-      username: 'aron0228',
-    }),
-  });
+      capacityPlanId: 8,
+      assignedHours: 6,
+    });
+    const repository = {
+      create: vi.fn().mockResolvedValue(assignment),
+    };
+    const capacityPlanRepository = {
+      findById: vi.fn().mockResolvedValue(new CapacityPlan({workspaceId: 3})),
+    };
+    const syncService = {
+      syncIssueAssignment: vi.fn().mockResolvedValue(undefined),
+    };
+    const authorization = createAuthorization();
+    const controller = new IssueAssignmentController(
+      repository as never,
+      capacityPlanRepository as never,
+      syncService as never,
+      authorization as never,
+    );
 
-  describeCrudController({
-    controllerName: 'IssueAssignmentController',
-    createController: repository =>
-      new IssueAssignmentController(
-        repository as never,
-        {
-          syncIssueAssignment: vi.fn().mockResolvedValue(undefined),
-        } as never,
-      ),
-    id: 9,
-    filter: {where: {capacityPlanId: 8}},
-    where: {capacityPlanId: 8},
-    entityFactory: () =>
-      new IssueAssignment({
-        id: 9,
+    await expect(
+      controller.create({id: 7} as never, {
         issueId: 11,
         userId: 5,
         capacityPlanId: 8,
         assignedHours: 6,
       }),
-    createPayloadFactory: () => ({
-      issueId: 11,
-      userId: 5,
-      capacityPlanId: 8,
-      assignedHours: 6,
-    }),
-    updatePayloadFactory: () => ({
-      assignedHours: 8,
-    }),
-    relationName: 'capacityPlan',
-    relationValueFactory: () => ({
-      id: 8,
-      workspaceId: 3,
-    }),
-  });
-
-  it('syncs issue assignments after creation', async () => {
-    const repository = {
-      create: vi.fn().mockResolvedValue(
-        new IssueAssignment({
-          id: 9,
-          issueId: 11,
-          userId: 5,
-          capacityPlanId: 8,
-          assignedHours: 6,
-        }),
-      ),
-    };
-    const syncService = {
-      syncIssueAssignment: vi.fn().mockResolvedValue(undefined),
-    };
-    const controller = new IssueAssignmentController(
-      repository as never,
-      syncService as never,
+    ).resolves.toBe(assignment);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
     );
-    const payload = {
-      issueId: 11,
-      userId: 5,
-      capacityPlanId: 8,
-      assignedHours: 6,
-    };
-
-    await expect(controller.create(payload)).resolves.toMatchObject({
-      id: 9,
-      issueId: 11,
-      userId: 5,
-    });
-    expect(syncService.syncIssueAssignment).toHaveBeenCalledWith(
-      expect.objectContaining({id: 9}),
-    );
+    expect(syncService.syncIssueAssignment).toHaveBeenCalledWith(assignment);
   });
 
   it('keeps issue assignment creation successful if GitHub sync fails', async () => {
@@ -154,6 +146,9 @@ describe('Planning controllers (unit)', () => {
     const repository = {
       create: vi.fn().mockResolvedValue(assignment),
     };
+    const capacityPlanRepository = {
+      findById: vi.fn().mockResolvedValue(new CapacityPlan({workspaceId: 3})),
+    };
     const syncService = {
       syncIssueAssignment: vi.fn().mockRejectedValue(new Error('GitHub')),
     };
@@ -162,11 +157,13 @@ describe('Planning controllers (unit)', () => {
       .mockImplementation(() => undefined);
     const controller = new IssueAssignmentController(
       repository as never,
+      capacityPlanRepository as never,
       syncService as never,
+      createAuthorization() as never,
     );
 
     await expect(
-      controller.create({
+      controller.create({id: 7} as never, {
         issueId: 12,
         userId: 6,
         capacityPlanId: 8,

--- a/api/src/__tests__/unit/controllers/planning.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/planning.controller.test.ts
@@ -66,6 +66,61 @@ describe('Planning controllers (unit)', () => {
     );
   });
 
+  it('covers capacity plan count, single reads, relations, and mutations', async () => {
+    const plan = new CapacityPlan({
+      id: 8,
+      workspaceId: 3,
+      start: '2026-04-13T08:00:00.000Z',
+      end: '2026-04-17T17:00:00.000Z',
+    });
+    const repository = {
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({...plan, entries: [{id: 4}]}),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const authorization = createAuthorization();
+    const controller = new CapacityPlanController(
+      repository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.count({id: 7} as never, {workspaceId: 3}),
+    ).resolves.toEqual({
+      count: 1,
+    });
+    await expect(
+      controller.findById({id: 7} as never, 8),
+    ).resolves.toMatchObject({
+      id: 8,
+    });
+    await expect(
+      controller.getRelation({id: 7} as never, 8, 'entries'),
+    ).resolves.toEqual([{id: 4}]);
+    await expect(
+      controller.updateById({id: 7} as never, 8, {
+        end: '2026-04-18T17:00:00.000Z',
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById({id: 7} as never, 8, plan),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById({id: 7} as never, 8),
+    ).resolves.toBeUndefined();
+
+    expect(repository.count).toHaveBeenCalledWith({
+      and: [{workspaceId: 3}, {workspaceId: {inq: [3]}}],
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
+  });
+
   it('scopes capacity plan entries through accessible capacity plans', async () => {
     const entryRepository = {
       find: vi.fn().mockResolvedValue([
@@ -93,6 +148,132 @@ describe('Planning controllers (unit)', () => {
         and: [{userId: 5}, {capacityPlanId: {inq: [8]}}],
       },
     });
+  });
+
+  it('covers capacity plan entry count, single reads, relations, and mutations', async () => {
+    const entry = new CapacityPlanEntry({
+      id: 4,
+      capacityPlanId: 8,
+      userId: 5,
+      capacityHours: 24,
+    });
+    const entryRepository = {
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({...entry, user: {id: 5}}),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const capacityPlanRepository = {
+      find: vi
+        .fn()
+        .mockResolvedValue([new CapacityPlan({id: 8, workspaceId: 3})]),
+      findById: vi
+        .fn()
+        .mockResolvedValue(new CapacityPlan({id: 8, workspaceId: 3})),
+    };
+    const authorization = createAuthorization();
+    const controller = new CapacityPlanEntryController(
+      entryRepository as never,
+      capacityPlanRepository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.count({id: 7} as never, {userId: 5}),
+    ).resolves.toEqual({
+      count: 1,
+    });
+    await expect(
+      controller.findById({id: 7} as never, 4),
+    ).resolves.toMatchObject({
+      id: 4,
+    });
+    await expect(
+      controller.getRelation({id: 7} as never, 4, 'user'),
+    ).resolves.toEqual({id: 5});
+    await expect(
+      controller.updateById({id: 7} as never, 4, {capacityHours: 28}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById({id: 7} as never, 4, entry),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById({id: 7} as never, 4),
+    ).resolves.toBeUndefined();
+
+    expect(entryRepository.count).toHaveBeenCalledWith({
+      and: [{userId: 5}, {capacityPlanId: {inq: [8]}}],
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
+  });
+
+  it('covers issue assignment count, single reads, relations, and mutations', async () => {
+    const assignment = new IssueAssignment({
+      id: 9,
+      issueId: 11,
+      userId: 5,
+      capacityPlanId: 8,
+      assignedHours: 6,
+    });
+    const assignmentRepository = {
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({...assignment, user: {id: 5}}),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const capacityPlanRepository = {
+      find: vi
+        .fn()
+        .mockResolvedValue([new CapacityPlan({id: 8, workspaceId: 3})]),
+      findById: vi
+        .fn()
+        .mockResolvedValue(new CapacityPlan({id: 8, workspaceId: 3})),
+    };
+    const authorization = createAuthorization();
+    const controller = new IssueAssignmentController(
+      assignmentRepository as never,
+      capacityPlanRepository as never,
+      {syncIssueAssignment: vi.fn()} as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.count({id: 7} as never, {userId: 5}),
+    ).resolves.toEqual({
+      count: 1,
+    });
+    await expect(
+      controller.findById({id: 7} as never, 9),
+    ).resolves.toMatchObject({
+      id: 9,
+    });
+    await expect(
+      controller.getRelation({id: 7} as never, 9, 'user'),
+    ).resolves.toEqual({id: 5});
+    await expect(
+      controller.updateById({id: 7} as never, 9, {assignedHours: 8}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById({id: 7} as never, 9, assignment),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById({id: 7} as never, 9),
+    ).resolves.toBeUndefined();
+
+    expect(assignmentRepository.count).toHaveBeenCalledWith({
+      and: [{userId: 5}, {capacityPlanId: {inq: [8]}}],
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
   });
 
   it('syncs issue assignments after authorized creation', async () => {

--- a/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
@@ -1,35 +1,80 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {GithubPullRequestController} from '../../../controllers/github/pull-request.controller';
+import {GithubPullRequest} from '../../../models';
 
 describe('GithubPullRequestController (unit)', () => {
-  let pullRequestService: {
-    deleteById: ReturnType<typeof vi.fn>;
-    deleteAll: ReturnType<typeof vi.fn>;
+  let pullRequestRepository: {
+    find: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  let repositoryRepository: {
+    find: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  let pullRequestService: {deleteById: ReturnType<typeof vi.fn>};
+  let authorization: {
+    getAuthenticatedUserId: ReturnType<typeof vi.fn>;
+    accessibleWorkspaceIds: ReturnType<typeof vi.fn>;
+    assertWorkspaceMember: ReturnType<typeof vi.fn>;
+    assertWorkspaceAdminOrOwner: ReturnType<typeof vi.fn>;
   };
   let controller: GithubPullRequestController;
 
   beforeEach(() => {
+    pullRequestRepository = {
+      find: vi.fn(),
+      findById: vi.fn(),
+    };
+    repositoryRepository = {
+      find: vi.fn().mockResolvedValue([{id: 8, workspaceId: 4}]),
+      findById: vi.fn().mockResolvedValue({id: 8, workspaceId: 4}),
+    };
     pullRequestService = {
       deleteById: vi.fn().mockResolvedValue(undefined),
-      deleteAll: vi.fn().mockResolvedValue({count: 3}),
+    };
+    authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([4]),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+      assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
     };
 
     controller = new GithubPullRequestController(
-      {} as never,
+      pullRequestRepository as never,
+      repositoryRepository as never,
       pullRequestService as never,
+      authorization as never,
     );
   });
 
-  it('deletes a single pull request through PullRequestService', async () => {
-    await expect(controller.deleteById(5)).resolves.toBeUndefined();
-    expect(pullRequestService.deleteById).toHaveBeenCalledWith(5);
+  it('scopes pull request lists to accessible repositories', async () => {
+    const pullRequest = new GithubPullRequest({id: 5, repositoryId: 8});
+    pullRequestRepository.find.mockResolvedValue([pullRequest]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {status: 'open'}}),
+    ).resolves.toEqual([pullRequest]);
+
+    expect(pullRequestRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{status: 'open'}, {repositoryId: {inq: [8]}}],
+      },
+    });
   });
 
-  it('deletes matching pull requests through PullRequestService', async () => {
-    const where = {repositoryId: 8} as never;
+  it('deletes pull requests through PullRequestService after admin check', async () => {
+    pullRequestRepository.findById.mockResolvedValue(
+      new GithubPullRequest({id: 5, repositoryId: 8}),
+    );
 
-    await expect(controller.deleteAll(where)).resolves.toEqual({count: 3});
-    expect(pullRequestService.deleteAll).toHaveBeenCalledWith(where);
+    await expect(
+      controller.deleteById({id: 7} as never, 5),
+    ).resolves.toBeUndefined();
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      4,
+      7,
+    );
+    expect(pullRequestService.deleteById).toHaveBeenCalledWith(5);
   });
 });

--- a/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
@@ -6,7 +6,10 @@ import {GithubPullRequest} from '../../../models';
 describe('GithubPullRequestController (unit)', () => {
   let pullRequestRepository: {
     find: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
     findById: ReturnType<typeof vi.fn>;
+    updateById: ReturnType<typeof vi.fn>;
+    replaceById: ReturnType<typeof vi.fn>;
   };
   let repositoryRepository: {
     find: ReturnType<typeof vi.fn>;
@@ -24,7 +27,10 @@ describe('GithubPullRequestController (unit)', () => {
   beforeEach(() => {
     pullRequestRepository = {
       find: vi.fn(),
+      count: vi.fn(),
       findById: vi.fn(),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
     };
     repositoryRepository = {
       find: vi.fn().mockResolvedValue([{id: 8, workspaceId: 4}]),
@@ -76,5 +82,48 @@ describe('GithubPullRequestController (unit)', () => {
       7,
     );
     expect(pullRequestService.deleteById).toHaveBeenCalledWith(5);
+  });
+
+  it('covers pull request counts, single reads, relations, and updates', async () => {
+    pullRequestRepository.count.mockResolvedValue({count: 1});
+    pullRequestRepository.findById.mockResolvedValue({
+      id: 5,
+      repositoryId: 8,
+      author: {id: 7},
+    });
+
+    await expect(
+      controller.count({id: 7} as never, {status: 'open'}),
+    ).resolves.toEqual({count: 1});
+    await expect(
+      controller.findById({id: 7} as never, 5),
+    ).resolves.toMatchObject({
+      id: 5,
+    });
+    await expect(
+      controller.getRelation({id: 7} as never, 5, 'author'),
+    ).resolves.toEqual({id: 7});
+    await expect(
+      controller.updateById({id: 7} as never, 5, {status: 'merged'}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById({id: 7} as never, 5, {
+        repositoryId: 8,
+        githubPrNumber: 13,
+        title: 'Update auth',
+        status: 'open',
+        description: 'Auth changes',
+      }),
+    ).resolves.toBeUndefined();
+    await expect(controller.deleteAll()).resolves.toEqual({count: 0});
+
+    expect(pullRequestRepository.count).toHaveBeenCalledWith({
+      and: [{status: 'open'}, {repositoryId: {inq: [8]}}],
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(4, 7);
+    expect(pullRequestRepository.updateById).toHaveBeenCalledWith(5, {
+      status: 'merged',
+    });
+    expect(pullRequestRepository.replaceById).toHaveBeenCalled();
   });
 });

--- a/api/src/__tests__/unit/controllers/rbac-managed-controllers.test.ts
+++ b/api/src/__tests__/unit/controllers/rbac-managed-controllers.test.ts
@@ -1,0 +1,316 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {GithubRepositoryController} from '../../../controllers/github/repository.controller';
+import {ExpertiseController} from '../../../controllers/system/expertise.controller';
+import {NewsFeedEntryExpertiseAssocController} from '../../../controllers/system/news-feed-entry-expertise-assoc.controller';
+import {UserExpertiseAssocController} from '../../../controllers/system/user-expertise-assoc.controller';
+import {
+  Expertise,
+  GithubRepository,
+  NewsFeedEntry,
+  NewsFeedEntryExpertiseAssoc,
+  UserExpertiseAssoc,
+} from '../../../models';
+
+const userProfile = {id: 7} as never;
+
+const createAuthorization = () => ({
+  getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+  accessibleWorkspaceIds: vi.fn().mockResolvedValue([3]),
+  assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+  assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
+});
+
+describe('RBAC-managed explicit controllers (unit)', () => {
+  it('covers expertise scoped reads and admin mutations', async () => {
+    const expertise = new Expertise({
+      id: 12,
+      workspaceId: 3,
+      name: 'Frontend',
+      description: 'UI work',
+    });
+    const repository = {
+      find: vi.fn().mockResolvedValue([expertise]),
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({
+        ...expertise,
+        workspace: {id: 3},
+      }),
+      create: vi.fn().mockResolvedValue(expertise),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const authorization = createAuthorization();
+    const controller = new ExpertiseController(
+      repository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.find(userProfile, {where: {name: 'Frontend'}}),
+    ).resolves.toEqual([expertise]);
+    await expect(
+      controller.count(userProfile, {name: 'Frontend'}),
+    ).resolves.toEqual({count: 1});
+    await expect(controller.findById(userProfile, 12)).resolves.toMatchObject({
+      id: 12,
+    });
+    await expect(
+      controller.getRelation(userProfile, 12, 'workspace'),
+    ).resolves.toEqual({id: 3});
+    await expect(
+      controller.create(userProfile, {
+        workspaceId: 3,
+        name: 'Frontend',
+        description: 'UI work',
+      }),
+    ).resolves.toEqual(expertise);
+    await expect(
+      controller.updateById(userProfile, 12, {description: 'Design systems'}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById(userProfile, 12, {
+        workspaceId: 3,
+        name: 'Frontend',
+        description: 'Design systems',
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById(userProfile, 12),
+    ).resolves.toBeUndefined();
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{name: 'Frontend'}, {workspaceId: {inq: [3]}}],
+      },
+    });
+    expect(repository.count).toHaveBeenCalledWith({
+      and: [{name: 'Frontend'}, {workspaceId: {inq: [3]}}],
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
+  });
+
+  it('covers user expertise association scoping and admin mutations', async () => {
+    const assoc = new UserExpertiseAssoc({
+      id: 14,
+      userId: 9,
+      expertiseId: 12,
+    });
+    const assocRepository = {
+      find: vi.fn().mockResolvedValue([assoc]),
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({
+        ...assoc,
+        expertise: {id: 12},
+      }),
+      create: vi.fn().mockResolvedValue(assoc),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const expertiseRepository = {
+      find: vi
+        .fn()
+        .mockResolvedValue([new Expertise({id: 12, workspaceId: 3})]),
+      findById: vi
+        .fn()
+        .mockResolvedValue(new Expertise({id: 12, workspaceId: 3})),
+    };
+    const authorization = createAuthorization();
+    const controller = new UserExpertiseAssocController(
+      assocRepository as never,
+      expertiseRepository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.find(userProfile, {where: {userId: 9}}),
+    ).resolves.toEqual([assoc]);
+    await expect(controller.count(userProfile, {userId: 9})).resolves.toEqual({
+      count: 1,
+    });
+    await expect(controller.findById(userProfile, 14)).resolves.toMatchObject({
+      id: 14,
+    });
+    await expect(
+      controller.getRelation(userProfile, 14, 'expertise'),
+    ).resolves.toEqual({id: 12});
+    await expect(
+      controller.create(userProfile, {userId: 9, expertiseId: 12}),
+    ).resolves.toEqual(assoc);
+    await expect(
+      controller.updateById(userProfile, 14, {userId: 10}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById(userProfile, 14, {userId: 10, expertiseId: 12}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById(userProfile, 14),
+    ).resolves.toBeUndefined();
+
+    expect(assocRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{userId: 9}, {expertiseId: {inq: [12]}}],
+      },
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
+  });
+
+  it('covers GitHub repository scoped reads and admin mutations', async () => {
+    const githubRepository = new GithubRepository({
+      id: 4,
+      workspaceId: 3,
+      githubRepoId: 100,
+      name: 'api',
+      fullName: 'team/api',
+    });
+    const repository = {
+      find: vi.fn().mockResolvedValue([githubRepository]),
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({
+        ...githubRepository,
+        workspace: {id: 3},
+      }),
+      create: vi.fn().mockResolvedValue(githubRepository),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteCascade: vi.fn().mockResolvedValue(undefined),
+    };
+    const authorization = createAuthorization();
+    const controller = new GithubRepositoryController(
+      repository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.find(userProfile, {where: {name: 'api'}}),
+    ).resolves.toEqual([githubRepository]);
+    await expect(controller.count(userProfile, {name: 'api'})).resolves.toEqual(
+      {
+        count: 1,
+      },
+    );
+    await expect(controller.findById(userProfile, 4)).resolves.toMatchObject({
+      id: 4,
+    });
+    await expect(
+      controller.getRelation(userProfile, 4, 'workspace'),
+    ).resolves.toEqual({id: 3});
+    await expect(
+      controller.create(userProfile, {
+        workspaceId: 3,
+        githubRepoId: 100,
+        name: 'api',
+        fullName: 'team/api',
+      }),
+    ).resolves.toEqual(githubRepository);
+    await expect(
+      controller.updateById(userProfile, 4, {name: 'backend'}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById(userProfile, 4, {
+        workspaceId: 3,
+        githubRepoId: 100,
+        name: 'backend',
+        fullName: 'team/backend',
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById(userProfile, 4),
+    ).resolves.toBeUndefined();
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{name: 'api'}, {workspaceId: {inq: [3]}}],
+      },
+    });
+    expect(repository.deleteCascade).toHaveBeenCalledWith(4);
+  });
+
+  it('covers news feed expertise association scoping and workspace checks', async () => {
+    const assoc = new NewsFeedEntryExpertiseAssoc({
+      id: 19,
+      newsFeedEntryId: 21,
+      expertiseId: 12,
+    });
+    const assocRepository = {
+      find: vi.fn().mockResolvedValue([assoc]),
+      count: vi.fn().mockResolvedValue({count: 1}),
+      findById: vi.fn().mockResolvedValue({
+        ...assoc,
+        expertise: {id: 12},
+      }),
+      create: vi.fn().mockResolvedValue(assoc),
+      updateById: vi.fn().mockResolvedValue(undefined),
+      replaceById: vi.fn().mockResolvedValue(undefined),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
+    const entryRepository = {
+      find: vi
+        .fn()
+        .mockResolvedValue([new NewsFeedEntry({id: 21, workspaceId: 3})]),
+      findById: vi
+        .fn()
+        .mockResolvedValue(new NewsFeedEntry({id: 21, workspaceId: 3})),
+    };
+    const expertiseRepository = {
+      findById: vi
+        .fn()
+        .mockResolvedValue(new Expertise({id: 12, workspaceId: 3})),
+    };
+    const authorization = createAuthorization();
+    const controller = new NewsFeedEntryExpertiseAssocController(
+      assocRepository as never,
+      entryRepository as never,
+      expertiseRepository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.find(userProfile, {where: {expertiseId: 12}}),
+    ).resolves.toEqual([assoc]);
+    await expect(
+      controller.count(userProfile, {expertiseId: 12}),
+    ).resolves.toEqual({count: 1});
+    await expect(controller.findById(userProfile, 19)).resolves.toMatchObject({
+      id: 19,
+    });
+    await expect(
+      controller.getRelation(userProfile, 19, 'expertise'),
+    ).resolves.toEqual({id: 12});
+    await expect(
+      controller.create(userProfile, {newsFeedEntryId: 21, expertiseId: 12}),
+    ).resolves.toEqual(assoc);
+    await expect(
+      controller.updateById(userProfile, 19, {expertiseId: 12}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById(userProfile, 19, {
+        newsFeedEntryId: 21,
+        expertiseId: 12,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.deleteById(userProfile, 19),
+    ).resolves.toBeUndefined();
+
+    expect(assocRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{expertiseId: 12}, {newsFeedEntryId: {inq: [21]}}],
+      },
+    });
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      3,
+      7,
+    );
+  });
+});

--- a/api/src/__tests__/unit/controllers/user.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/user.controller.test.ts
@@ -1,40 +1,60 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
-import {User} from '../../../models';
 import {UserController} from '../../../controllers/auth/user.controller';
-import {describeCrudController} from './test-helpers';
+import {User} from '../../../models';
 
 describe('UserController (unit)', () => {
-  describeCrudController({
-    controllerName: 'UserController',
-    createController: repository => new UserController(repository as never),
-    id: 7,
-    filter: {where: {username: 'aron0228'}},
-    where: {githubId: 1},
-    entityFactory: () =>
-      new User({
-        id: 7,
-        githubId: 1,
-        username: 'aron0228',
-        fullName: 'Reszegi Aron',
-        email: 'aron@example.com',
-        avatarUrl: 'https://example.com/avatar.png',
-      }),
-    createPayloadFactory: () => ({
-      githubId: 1,
-      username: 'aron0228',
-      fullName: 'Reszegi Aron',
-      email: 'aron@example.com',
+  it('scopes users to the current user and shared workspaces', async () => {
+    const user = new User({
+      id: 8,
+      githubId: 2,
+      username: 'teammate',
+      fullName: 'Team Mate',
+      email: 'team@example.com',
       avatarUrl: 'https://example.com/avatar.png',
-    }),
-    updatePayloadFactory: () => ({
-      fullName: 'Updated Name',
-      avatarUrl: 'https://example.com/updated-avatar.png',
-    }),
+    });
+    const userRepository = {
+      find: vi.fn().mockResolvedValue([user]),
+      count: vi.fn(),
+      findById: vi.fn(),
+    };
+    const workspaceRepository = {
+      find: vi.fn().mockResolvedValue([{id: 11, ownerId: 7}]),
+    };
+    const workspaceMemberRepository = {
+      find: vi.fn().mockResolvedValue([
+        {workspaceId: 11, userId: 7},
+        {workspaceId: 11, userId: 8},
+      ]),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([11]),
+    };
+    const controller = new UserController(
+      userRepository as never,
+      workspaceRepository as never,
+      workspaceMemberRepository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.find({id: 7} as never, {where: {username: 'teammate'}}),
+    ).resolves.toEqual([user]);
+    expect(userRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{username: 'teammate'}, {id: {inq: [7, 8]}}],
+      },
+    });
   });
 
   it('returns the placeholder delete profile response', async () => {
-    const controller = new UserController({} as never);
+    const controller = new UserController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
 
     await expect(controller.deleteProfile()).resolves.toEqual({
       message: 'Not implemented',

--- a/api/src/__tests__/unit/controllers/workspace-member.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/workspace-member.controller.test.ts
@@ -1,36 +1,76 @@
-import {describe} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
-import {WorkspaceMember} from '../../../models';
 import {WorkspaceMemberController} from '../../../controllers/system/workspace-member.controller';
-import {describeCrudController} from './test-helpers';
+import {WorkspaceMember} from '../../../models';
 
 describe('WorkspaceMemberController (unit)', () => {
-  describeCrudController({
-    controllerName: 'WorkspaceMemberController',
-    createController: repository =>
-      new WorkspaceMemberController(repository as never),
-    id: 17,
-    filter: {where: {workspaceId: 11}},
-    where: {workspaceId: 11},
-    entityFactory: () =>
-      new WorkspaceMember({
-        id: 17,
-        userId: 7,
-        workspaceId: 11,
-        role: 'MEMBER',
+  const createController = () => {
+    const repository = {
+      find: vi.fn(),
+      count: vi.fn(),
+      findById: vi.fn(),
+      create: vi.fn(),
+      updateById: vi.fn(),
+      replaceById: vi.fn(),
+      deleteById: vi.fn(),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      mergeWorkspaceMemberAccessWhere: vi.fn().mockResolvedValue({
+        workspaceId: {inq: [11]},
       }),
-    createPayloadFactory: () => ({
-      userId: 7,
+      assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+      assertWorkspaceAdminOrOwner: vi.fn().mockResolvedValue('ADMIN'),
+    };
+
+    return {
+      repository,
+      authorization,
+      controller: new WorkspaceMemberController(
+        repository as never,
+        authorization as never,
+      ),
+    };
+  };
+
+  it('scopes member lists to accessible workspaces', async () => {
+    const {controller, repository, authorization} = createController();
+    const member = new WorkspaceMember({
+      id: 17,
       workspaceId: 11,
+      userId: 9,
       role: 'MEMBER',
-    }),
-    updatePayloadFactory: () => ({
-      role: 'ADMIN',
-    }),
-    relationName: 'user',
-    relationValueFactory: () => ({
-      id: 7,
-      username: 'aron0228',
-    }),
+    });
+    repository.find.mockResolvedValue([member]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {workspaceId: 11}}),
+    ).resolves.toEqual([member]);
+
+    expect(authorization.mergeWorkspaceMemberAccessWhere).toHaveBeenCalledWith(
+      {workspaceId: 11},
+      7,
+    );
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {workspaceId: {inq: [11]}},
+    });
+  });
+
+  it('requires admin or owner permissions before removing members', async () => {
+    const {controller, repository, authorization} = createController();
+    repository.findById.mockResolvedValue(
+      new WorkspaceMember({id: 17, workspaceId: 11, userId: 9}),
+    );
+    repository.deleteById.mockResolvedValue(undefined);
+
+    await expect(
+      controller.deleteById({id: 7} as never, 17),
+    ).resolves.toBeUndefined();
+
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      11,
+      7,
+    );
+    expect(repository.deleteById).toHaveBeenCalledWith(17);
   });
 });

--- a/api/src/__tests__/unit/controllers/workspace-member.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/workspace-member.controller.test.ts
@@ -73,4 +73,46 @@ describe('WorkspaceMemberController (unit)', () => {
     );
     expect(repository.deleteById).toHaveBeenCalledWith(17);
   });
+
+  it('covers member count, single reads, relations, and updates', async () => {
+    const {controller, repository, authorization} = createController();
+    repository.count.mockResolvedValue({count: 1});
+    repository.findById.mockResolvedValue({
+      id: 17,
+      workspaceId: 11,
+      userId: 9,
+      role: 'MEMBER',
+      user: {id: 9},
+    });
+    repository.updateById.mockResolvedValue(undefined);
+    repository.replaceById.mockResolvedValue(undefined);
+
+    await expect(
+      controller.count({id: 7} as never, {workspaceId: 11}),
+    ).resolves.toEqual({count: 1});
+    await expect(
+      controller.findById({id: 7} as never, 17),
+    ).resolves.toMatchObject({id: 17});
+    await expect(
+      controller.getRelation({id: 7} as never, 17, 'user'),
+    ).resolves.toEqual({id: 9});
+    await expect(
+      controller.updateById({id: 7} as never, 17, {role: 'ADMIN'}),
+    ).resolves.toBeUndefined();
+    await expect(
+      controller.replaceById(
+        {id: 7} as never,
+        17,
+        new WorkspaceMember({workspaceId: 11, userId: 9, role: 'ADMIN'}),
+      ),
+    ).resolves.toBeUndefined();
+    await expect(controller.updateAll()).resolves.toEqual({count: 0});
+    await expect(controller.deleteAll()).resolves.toEqual({count: 0});
+
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(11, 7);
+    expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
+      11,
+      7,
+    );
+  });
 });

--- a/api/src/__tests__/unit/controllers/workspace.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/workspace.controller.test.ts
@@ -1,37 +1,82 @@
-import {describe} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
-import {Workspace} from '../../../models';
 import {WorkspaceController} from '../../../controllers/system/workspace.controller';
-import {describeCrudController} from './test-helpers';
+import {Workspace} from '../../../models';
 
 describe('WorkspaceController (unit)', () => {
-  describeCrudController({
-    controllerName: 'WorkspaceController',
-    createController: repository =>
-      new WorkspaceController(repository as never),
-    id: 11,
-    filter: {where: {ownerId: 7}},
-    where: {ownerId: 7},
-    entityFactory: () =>
-      new Workspace({
-        id: 11,
-        name: 'Demo Workspace',
-        ownerId: 7,
-        avatarUrl: 'https://example.com/workspace.png',
+  const createController = () => {
+    const repository = {
+      find: vi.fn(),
+      count: vi.fn(),
+      findById: vi.fn(),
+      create: vi.fn(),
+      updateById: vi.fn(),
+      replaceById: vi.fn(),
+      deleteById: vi.fn(),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(7),
+      mergeWorkspaceAccessFilter: vi.fn().mockResolvedValue({
+        where: {ownerId: 7},
       }),
-    createPayloadFactory: () => ({
-      name: 'Demo Workspace',
+      assertWorkspaceOwner: vi.fn().mockResolvedValue('OWNER'),
+      assertWorkspaceMember: vi.fn().mockResolvedValue('OWNER'),
+    };
+
+    return {
+      repository,
+      authorization,
+      controller: new WorkspaceController(
+        repository as never,
+        authorization as never,
+      ),
+    };
+  };
+
+  it('scopes workspace listing to the authenticated user', async () => {
+    const {controller, repository, authorization} = createController();
+    const workspace = new Workspace({id: 11, name: 'Demo', ownerId: 7});
+    repository.find.mockResolvedValue([workspace]);
+
+    await expect(
+      controller.find({id: 7} as never, {where: {name: 'Demo'}}),
+    ).resolves.toEqual([workspace]);
+
+    expect(authorization.mergeWorkspaceAccessFilter).toHaveBeenCalledWith(
+      {where: {name: 'Demo'}},
+      7,
+    );
+    expect(repository.find).toHaveBeenCalledWith({where: {ownerId: 7}});
+  });
+
+  it('creates workspaces owned by the authenticated user', async () => {
+    const {controller, repository} = createController();
+    const workspace = new Workspace({id: 11, name: 'Demo', ownerId: 7});
+    repository.create.mockResolvedValue(workspace);
+
+    await expect(
+      controller.create({id: 7} as never, {name: 'Demo', ownerId: 99}),
+    ).resolves.toEqual(workspace);
+
+    expect(repository.create).toHaveBeenCalledWith({
+      name: 'Demo',
       ownerId: 7,
-      avatarUrl: 'https://example.com/workspace.png',
-    }),
-    updatePayloadFactory: () => ({
-      name: 'Updated Workspace',
-      avatarUrl: 'https://example.com/updated-workspace.png',
-    }),
-    relationName: 'owner',
-    relationValueFactory: () => ({
-      id: 7,
-      username: 'aron0228',
-    }),
+    });
+  });
+
+  it('requires workspace owner for AI and sync settings updates', async () => {
+    const {controller, repository, authorization} = createController();
+    repository.updateById.mockResolvedValue(undefined);
+
+    await expect(
+      controller.updateById({id: 7} as never, 11, {
+        capacityPlanningSync: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(authorization.assertWorkspaceOwner).toHaveBeenCalledWith(11, 7);
+    expect(repository.updateById).toHaveBeenCalledWith(11, {
+      capacityPlanningSync: false,
+    });
   });
 });

--- a/api/src/__tests__/unit/interceptors/json-api-deserializer.interceptor.test.ts
+++ b/api/src/__tests__/unit/interceptors/json-api-deserializer.interceptor.test.ts
@@ -7,11 +7,12 @@ import {JsonApiDeserializerInterceptor} from '../../../interceptors/json-api-des
 const buildInvocationContext = (
   args: unknown[],
   entityClass?: typeof Workspace,
+  repositoryProperty = 'repository',
 ): InvocationContext =>
   ({
     args,
     target: {
-      repository: entityClass ? {entityClass} : undefined,
+      [repositoryProperty]: entityClass ? {entityClass} : undefined,
     },
   }) as InvocationContext;
 
@@ -115,6 +116,41 @@ describe('JsonApiDeserializerInterceptor (unit)', () => {
       {name: 'Workspace One', ownerId: 1},
       {name: 'Workspace Two', ownerId: 2},
     ]);
+  });
+
+  it('discovers entity metadata from named controller repositories', async () => {
+    const request = {
+      headers: {'content-type': 'application/vnd.api+json'},
+      body: {
+        data: {
+          attributes: {
+            name: 'Demo Workspace',
+          },
+          relationships: {
+            owner: {
+              data: {id: 7},
+            },
+          },
+        },
+      },
+    };
+    const args = [{data: request.body}];
+    const interceptor = new JsonApiDeserializerInterceptor(request as never);
+    const invoke = await interceptor.value();
+
+    await expect(
+      invoke(
+        buildInvocationContext(args, Workspace, 'workspaceRepository'),
+        async () => request.body,
+      ),
+    ).resolves.toEqual({
+      name: 'Demo Workspace',
+      ownerId: 7,
+    });
+    expect(args[0]).toEqual({
+      name: 'Demo Workspace',
+      ownerId: 7,
+    });
   });
 
   it('maps null belongsTo relationship data to null foreign keys', async () => {

--- a/api/src/__tests__/unit/interceptors/json-api-serializer.interceptor.test.ts
+++ b/api/src/__tests__/unit/interceptors/json-api-serializer.interceptor.test.ts
@@ -25,10 +25,11 @@ const createResponse = () => {
 const buildInvocationContext = (
   entityClass?: typeof Workspace | typeof User,
   targetName?: string,
+  repositoryProperty = 'repository',
 ): InvocationContext =>
   ({
     target: {
-      repository: entityClass ? {entityClass} : undefined,
+      [repositoryProperty]: entityClass ? {entityClass} : undefined,
     },
     targetName,
   }) as InvocationContext;
@@ -168,6 +169,37 @@ describe('JsonApiSerializerInterceptor (unit)', () => {
     expect(payload.data[1].links.self).toBe(
       'https://api.example.com/workspaces/12',
     );
+  });
+
+  it('discovers entity metadata from named controller repositories', async () => {
+    const request = {
+      originalUrl: '/workspaces',
+      path: '/workspaces',
+      params: {},
+    };
+    const {response, state} = createResponse();
+    const interceptor = new JsonApiSerializerInterceptor(
+      request as never,
+      response as never,
+    );
+    const invoke = await interceptor.value();
+
+    await invoke(
+      buildInvocationContext(Workspace, undefined, 'workspaceRepository'),
+      async () => [
+        new Workspace({
+          id: 11,
+          name: 'Workspace One',
+          ownerId: 7,
+        }),
+      ],
+    );
+
+    const payload = JSON.parse(state.payload ?? '');
+
+    expect(state.header).toBe('application/vnd.api+json');
+    expect(payload.data[0].type).toBe('workspaces');
+    expect(payload.data[0].attributes.name).toBe('Workspace One');
   });
 
   it('includes loaded relations in the included payload', async () => {

--- a/api/src/__tests__/unit/security/workspace-rbac.test.ts
+++ b/api/src/__tests__/unit/security/workspace-rbac.test.ts
@@ -1,0 +1,123 @@
+import {HttpErrors} from '@loopback/rest';
+import {describe, expect, it, vi} from 'vitest';
+
+import {AuthorizationController} from '../../../controllers/system/authorization.controller';
+import {WORKSPACE_PERMISSION, WORKSPACE_ROLE} from '../../../constants';
+import {GithubIssueController} from '../../../controllers/github/issue.controller';
+import {WorkspaceAuthorizationService} from '../../../services';
+
+describe('Workspace RBAC security contract (unit)', () => {
+  const createAuthorizationService = () => {
+    const workspaceRepository = {
+      findById: vi.fn(),
+      find: vi.fn(),
+    };
+    const workspaceMemberRepository = {
+      findOne: vi.fn(),
+      find: vi.fn(),
+    };
+
+    return {
+      workspaceRepository,
+      workspaceMemberRepository,
+      service: new WorkspaceAuthorizationService(
+        workspaceRepository as never,
+        workspaceMemberRepository as never,
+      ),
+    };
+  };
+
+  it('denies outsiders from route permission checks', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createAuthorizationService();
+    workspaceRepository.findById.mockResolvedValue({id: 4, ownerId: 1});
+    workspaceMemberRepository.findOne.mockResolvedValue(null);
+    const controller = new AuthorizationController(service);
+
+    await expect(
+      controller.check({id: 99} as never, {
+        workspaceId: 4,
+        permission: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      permission: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+      workspaceId: 4,
+      role: null,
+    });
+  });
+
+  it('allows members to view workspaces but not manage protected settings', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createAuthorizationService();
+    workspaceRepository.findById.mockResolvedValue({id: 4, ownerId: 1});
+    workspaceMemberRepository.findOne.mockResolvedValue({
+      workspaceId: 4,
+      userId: 12,
+      role: 'MEMBER',
+    });
+
+    await expect(
+      service.checkPermission(4, 12, WORKSPACE_PERMISSION.WORKSPACE_VIEW),
+    ).resolves.toMatchObject({
+      allowed: true,
+      role: WORKSPACE_ROLE.MEMBER,
+    });
+    await expect(
+      service.checkPermission(
+        4,
+        12,
+        WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+      ),
+    ).resolves.toMatchObject({
+      allowed: false,
+      role: WORKSPACE_ROLE.MEMBER,
+    });
+  });
+
+  it('keeps GitHub issue queries scoped to accessible repository ids', async () => {
+    const issueRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+    const repositoryRepository = {
+      find: vi.fn().mockResolvedValue([{id: 10, workspaceId: 4}]),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(12),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([4]),
+    };
+    const controller = new GithubIssueController(
+      issueRepository as never,
+      repositoryRepository as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      authorization as never,
+    );
+
+    await controller.find({id: 12} as never, {
+      where: {
+        repositoryId: 999,
+      },
+    });
+
+    expect(issueRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{repositoryId: 999}, {repositoryId: {inq: [10]}}],
+      },
+    });
+  });
+
+  it('throws 403 when an outsider assertion reaches an API mutation', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createAuthorizationService();
+    workspaceRepository.findById.mockResolvedValue({id: 4, ownerId: 1});
+    workspaceMemberRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.assertWorkspaceAdminOrOwner(4, 99),
+    ).rejects.toBeInstanceOf(HttpErrors.Forbidden);
+  });
+});

--- a/api/src/__tests__/unit/security/workspace-rbac.test.ts
+++ b/api/src/__tests__/unit/security/workspace-rbac.test.ts
@@ -3,7 +3,11 @@ import {describe, expect, it, vi} from 'vitest';
 
 import {AuthorizationController} from '../../../controllers/system/authorization.controller';
 import {WORKSPACE_PERMISSION, WORKSPACE_ROLE} from '../../../constants';
+import {FileController} from '../../../controllers/system/file.controller';
 import {GithubIssueController} from '../../../controllers/github/issue.controller';
+import {NewsFeedEntryController} from '../../../controllers/system/news-feed-entry.controller';
+import {NewsFeedEntryExpertiseAssocController} from '../../../controllers/system/news-feed-entry-expertise-assoc.controller';
+import {UserController} from '../../../controllers/auth/user.controller';
 import {WorkspaceAuthorizationService} from '../../../services';
 
 describe('Workspace RBAC security contract (unit)', () => {
@@ -119,5 +123,107 @@ describe('Workspace RBAC security contract (unit)', () => {
     await expect(
       service.assertWorkspaceAdminOrOwner(4, 99),
     ).rejects.toBeInstanceOf(HttpErrors.Forbidden);
+  });
+
+  it('keeps user lookups scoped to self and shared workspace members', async () => {
+    const userRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+    const workspaceRepository = {
+      find: vi.fn().mockResolvedValue([{id: 4, ownerId: 12}]),
+    };
+    const workspaceMemberRepository = {
+      find: vi.fn().mockResolvedValue([{workspaceId: 4, userId: 14}]),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(12),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([4]),
+    };
+    const controller = new UserController(
+      userRepository as never,
+      workspaceRepository as never,
+      workspaceMemberRepository as never,
+      authorization as never,
+    );
+
+    await controller.find({id: 12} as never, {where: {id: 99}});
+
+    expect(userRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{id: 99}, {id: {inq: [12, 14]}}],
+      },
+    });
+  });
+
+  it('checks workspace membership before serving file previews', async () => {
+    const fileRepository = {
+      findById: vi.fn().mockResolvedValue({id: 22, workspaceId: 4}),
+      preview: vi.fn().mockResolvedValue({}),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(12),
+      accessibleWorkspaceIds: vi.fn(),
+      assertWorkspaceMember: vi
+        .fn()
+        .mockRejectedValue(new HttpErrors.Forbidden()),
+    };
+    const controller = new FileController(
+      fileRepository as never,
+      authorization as never,
+    );
+
+    await expect(
+      controller.preview({id: 12} as never, 22, {} as never),
+    ).rejects.toBeInstanceOf(HttpErrors.Forbidden);
+    expect(fileRepository.preview).not.toHaveBeenCalled();
+  });
+
+  it('scopes news feed expertise associations through accessible entries', async () => {
+    const assocRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+    const entryRepository = {
+      find: vi.fn().mockResolvedValue([{id: 31, workspaceId: 4}]),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(12),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([4]),
+    };
+    const controller = new NewsFeedEntryExpertiseAssocController(
+      assocRepository as never,
+      entryRepository as never,
+      {} as never,
+      authorization as never,
+    );
+
+    await controller.find({id: 12} as never, {where: {expertiseId: 99}});
+
+    expect(assocRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{expertiseId: 99}, {newsFeedEntryId: {inq: [31]}}],
+      },
+    });
+  });
+
+  it('keeps news feed entries scoped to accessible workspaces', async () => {
+    const newsFeedEntryRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+    const authorization = {
+      getAuthenticatedUserId: vi.fn().mockReturnValue(12),
+      accessibleWorkspaceIds: vi.fn().mockResolvedValue([4]),
+    };
+    const controller = new NewsFeedEntryController(
+      newsFeedEntryRepository as never,
+      authorization as never,
+    );
+
+    await controller.find({id: 12} as never, {where: {workspaceId: 999}});
+
+    expect(newsFeedEntryRepository.find).toHaveBeenCalledWith({
+      where: {
+        and: [{workspaceId: 999}, {workspaceId: {inq: [4]}}],
+      },
+    });
   });
 });

--- a/api/src/__tests__/unit/services/github.service.test.ts
+++ b/api/src/__tests__/unit/services/github.service.test.ts
@@ -246,7 +246,10 @@ describe('GithubService (unit)', () => {
       redirect: vi.fn(),
     };
 
-    const installationUrl = await service.getInstallationUrl('42');
+    const installationUrl = await service.getInstallationUrl({
+      workspaceId: 42,
+      userId: 7,
+    });
     const signedState = new URL(installationUrl).searchParams.get('state');
 
     expect(signedState).toBeTruthy();
@@ -283,7 +286,10 @@ describe('GithubService (unit)', () => {
       redirect: vi.fn(),
     };
 
-    const installationUrl = await service.getInstallationUrl('42');
+    const installationUrl = await service.getInstallationUrl({
+      workspaceId: 42,
+      userId: 7,
+    });
     const signedState = new URL(installationUrl).searchParams.get('state')!;
     const tamperedState = `${signedState.slice(0, -1)}${
       signedState.endsWith('a') ? 'b' : 'a'

--- a/api/src/__tests__/unit/services/github.service.test.ts
+++ b/api/src/__tests__/unit/services/github.service.test.ts
@@ -56,6 +56,11 @@ describe('GithubService (unit)', () => {
     updateById: ReturnType<typeof vi.fn>;
     deleteCascade: ReturnType<typeof vi.fn>;
   };
+  let installationStateRepository: {
+    create: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+    updateById: ReturnType<typeof vi.fn>;
+  };
   let queueService: {
     enqueueGithubIssuesSync: ReturnType<typeof vi.fn>;
     enqueueGithubLabelsSync: ReturnType<typeof vi.fn>;
@@ -85,6 +90,20 @@ describe('GithubService (unit)', () => {
       updateById: vi.fn().mockResolvedValue(undefined),
       deleteCascade: vi.fn().mockResolvedValue(undefined),
     };
+    installationStateRepository = {
+      create: vi.fn().mockImplementation(state => Promise.resolve(state)),
+      findById: vi.fn().mockImplementation((nonce: string) =>
+        Promise.resolve({
+          nonce,
+          workspaceId: 42,
+          userId: 7,
+          issuedAt: new Date(),
+          expiresAt: new Date(Date.now() + 60_000),
+          consumedAt: null,
+        }),
+      ),
+      updateById: vi.fn().mockResolvedValue(undefined),
+    };
     queueService = {
       enqueueGithubLabelsSync: vi.fn().mockResolvedValue(undefined),
       enqueueGithubIssuesSync: vi.fn().mockResolvedValue(undefined),
@@ -104,6 +123,7 @@ describe('GithubService (unit)', () => {
     service = new GithubService(
       async () => workspaceRepository as never,
       async () => githubRepositoryRepository as never,
+      async () => installationStateRepository as never,
       queueService as never,
       issuePriorityService as never,
     );
@@ -254,12 +274,70 @@ describe('GithubService (unit)', () => {
 
     expect(signedState).toBeTruthy();
     expect(signedState).not.toBe('42');
+    expect(installationStateRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 42,
+        userId: 7,
+        consumedAt: null,
+      }),
+    );
 
     await service.callback(response as never, '77', 'install', signedState!);
 
     expect(syncWorkspaceInstallationSpy).toHaveBeenCalledWith(42, 77);
+    expect(installationStateRepository.updateById).toHaveBeenCalledWith(
+      signedState!.split('.')[2],
+      expect.objectContaining({
+        consumedAt: expect.any(Date),
+      }),
+    );
     expect(response.redirect).toHaveBeenCalledWith(
       'https://client.example.com/workspaces/callback?workspaceId=42',
+    );
+  });
+
+  it('rejects replayed installation callback state tokens', async () => {
+    internals.getGithubAppInfo = vi.fn().mockResolvedValue({
+      slug: 'devteams-demo',
+      name: 'DevTeams Demo',
+    });
+    internals.getInstallation = vi.fn().mockResolvedValue({
+      id: 77,
+      account: null,
+      app_id: 1,
+      app_slug: 'devteams-demo',
+      target_id: 2,
+      target_type: 'Organization',
+      permissions: {},
+      events: [],
+    });
+    vi.spyOn(internals, 'listInstallationRepositories').mockResolvedValue([]);
+    const syncWorkspaceInstallationSpy = vi
+      .spyOn(internals, 'syncWorkspaceInstallation')
+      .mockResolvedValue(undefined);
+    const response = {
+      redirect: vi.fn(),
+    };
+
+    const installationUrl = await service.getInstallationUrl({
+      workspaceId: 42,
+      userId: 7,
+    });
+    const signedState = new URL(installationUrl).searchParams.get('state')!;
+    installationStateRepository.findById.mockResolvedValueOnce({
+      nonce: signedState.split('.')[2],
+      workspaceId: 42,
+      userId: 7,
+      issuedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: new Date(),
+    });
+
+    await service.callback(response as never, '77', 'install', signedState);
+
+    expect(syncWorkspaceInstallationSpy).not.toHaveBeenCalled();
+    expect(response.redirect).toHaveBeenCalledWith(
+      'https://client.example.com/workspaces/callback',
     );
   });
 

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -74,6 +74,29 @@ describe('IssuePriorityService (unit)', () => {
     });
   });
 
+  it('normalizes already analyzed predictions for queued issue creation', () => {
+    expect(
+      service.normalizePredictionInput({
+        priority: 'very high' as never,
+        reason: '  Authentication bypass is explicitly confirmed.  ',
+        estimatedHours: 8.4,
+        estimationConfidence: 'MEDIUM' as never,
+      }),
+    ).toEqual({
+      priority: 'Very-High',
+      reason: 'Authentication bypass is explicitly confirmed.',
+      estimatedHours: 8,
+      estimationConfidence: 'medium',
+    });
+
+    expect(
+      service.normalizePredictionInput({
+        priority: 'not-real' as never,
+        reason: 'Nope',
+      }),
+    ).toBeNull();
+  });
+
   it('removes the previous AI note before appending a new one', () => {
     const withNote = service.upsertPredictionNote('Original description', {
       priority: 'High',

--- a/api/src/__tests__/unit/services/workspace-authorization.service.test.ts
+++ b/api/src/__tests__/unit/services/workspace-authorization.service.test.ts
@@ -1,0 +1,99 @@
+import {HttpErrors} from '@loopback/rest';
+import {describe, expect, it, vi} from 'vitest';
+
+import {WORKSPACE_PERMISSION, WORKSPACE_ROLE} from '../../../constants';
+import {WorkspaceAuthorizationService} from '../../../services';
+
+describe('WorkspaceAuthorizationService (unit)', () => {
+  const createService = () => {
+    const workspaceRepository = {
+      findById: vi.fn(),
+      find: vi.fn(),
+    };
+    const workspaceMemberRepository = {
+      findOne: vi.fn(),
+      find: vi.fn(),
+    };
+
+    return {
+      workspaceRepository,
+      workspaceMemberRepository,
+      service: new WorkspaceAuthorizationService(
+        workspaceRepository as never,
+        workspaceMemberRepository as never,
+      ),
+    };
+  };
+
+  it('allows workspace owners to perform privileged actions', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createService();
+    workspaceRepository.findById.mockResolvedValue({id: 3, ownerId: 7});
+
+    await expect(
+      service.checkPermission(3, 7, WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE),
+    ).resolves.toEqual({
+      allowed: true,
+      permission: WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE,
+      workspaceId: 3,
+      role: WORKSPACE_ROLE.OWNER,
+    });
+
+    expect(workspaceMemberRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('allows admins to manage members but denies owner-only settings', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createService();
+    workspaceRepository.findById.mockResolvedValue({id: 3, ownerId: 1});
+    workspaceMemberRepository.findOne.mockResolvedValue({
+      workspaceId: 3,
+      userId: 7,
+      role: 'ADMIN',
+    });
+
+    await expect(
+      service.checkPermission(
+        3,
+        7,
+        WORKSPACE_PERMISSION.WORKSPACE_MEMBERS_MANAGE,
+      ),
+    ).resolves.toMatchObject({allowed: true, role: WORKSPACE_ROLE.ADMIN});
+    await expect(
+      service.checkPermission(3, 7, WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE),
+    ).resolves.toMatchObject({allowed: true, role: WORKSPACE_ROLE.ADMIN});
+    await expect(
+      service.checkPermission(3, 7, WORKSPACE_PERMISSION.AI_SETTINGS_MANAGE),
+    ).resolves.toMatchObject({allowed: false, role: WORKSPACE_ROLE.ADMIN});
+  });
+
+  it('denies non-members and throws when asserted', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createService();
+    workspaceRepository.findById.mockResolvedValue({id: 3, ownerId: 1});
+    workspaceMemberRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.checkPermission(3, 7, WORKSPACE_PERMISSION.WORKSPACE_VIEW),
+    ).resolves.toMatchObject({allowed: false, role: null});
+    await expect(service.assertWorkspaceMember(3, 7)).rejects.toBeInstanceOf(
+      HttpErrors.Forbidden,
+    );
+  });
+
+  it('merges workspace access into filters', async () => {
+    const {service, workspaceMemberRepository} = createService();
+    workspaceMemberRepository.find.mockResolvedValue([
+      {workspaceId: 3},
+      {workspaceId: 4},
+    ]);
+
+    await expect(
+      service.mergeWorkspaceAccessFilter({where: {name: 'API'}}, 7),
+    ).resolves.toEqual({
+      where: {
+        and: [{name: 'API'}, {or: [{ownerId: 7}, {id: {inq: [3, 4]}}]}],
+      },
+    });
+  });
+});

--- a/api/src/application.ts
+++ b/api/src/application.ts
@@ -9,6 +9,11 @@ import {ServiceMixin} from '@loopback/service-proxy';
 import path from 'path';
 import {RestApplication} from '@loopback/rest';
 import {CronComponent} from '@loopback/cron';
+import {
+  AuthorizationComponent,
+  AuthorizationDecision,
+  AuthorizationTags,
+} from '@loopback/authorization';
 import {MySequence} from './sequence';
 import {PostgresDbDataSource} from './datasources';
 import {JsonApiSerializerInterceptor} from './interceptors/json-api-serializer.interceptor';
@@ -20,27 +25,11 @@ import {
 } from '@loopback/authentication';
 import {JwtTokenStrategy} from './strategies/jwt-token.strategy';
 import {QueryTokenStrategy} from './strategies/query-token.strategy';
+import {PrReviewReminderSchedulerService} from './services';
 import {
-  GithubService,
-  GithubWebhookService,
-  IssuePriorityService,
-  GithubOauthService,
-  IssueService,
-  AIPredictionService,
-  JwtTokenService,
-  LabelService,
-  NewsFeedPredictionService,
-  OllamaService,
-  PullRequestMergeRiskService,
-  PullRequestService,
-  QueueService,
-  CapacityPlanningSyncService,
-  CommunicationService,
-  CommunicationSocketService,
-  PrReviewReminderSchedulerService,
-  PullRequestReviewReminderService,
-  RedisService,
-} from './services';
+  WORKSPACE_AUTHORIZER,
+  WorkspaceAuthorizerProvider,
+} from './authorization/workspace-authorizer.provider';
 
 export {ApplicationConfig};
 
@@ -72,27 +61,17 @@ export class RestApi extends BootMixin(
     this.component(RestExplorerComponent);
     this.component(JWTAuthenticationComponent);
     this.component(AuthenticationComponent);
+    const authorizationBinding = this.component(AuthorizationComponent);
+    this.configure(authorizationBinding.key).to({
+      precedence: AuthorizationDecision.DENY,
+      defaultDecision: AuthorizationDecision.DENY,
+    });
     this.component(CronComponent);
 
-    this.service(RedisService);
-    this.service(QueueService);
-    this.service(AIPredictionService);
-    this.service(JwtTokenService);
-    this.service(GithubOauthService);
-    this.service(OllamaService);
-    this.service(IssuePriorityService);
-    this.service(PullRequestMergeRiskService);
-    this.service(GithubService);
-    this.service(GithubWebhookService);
-    this.service(IssueService);
-    this.service(LabelService);
-    this.service(PullRequestService);
-    this.service(NewsFeedPredictionService);
-    this.service(CapacityPlanningSyncService);
-    this.service(CommunicationService);
-    this.service(CommunicationSocketService);
-    this.service(PullRequestReviewReminderService);
     this.lifeCycleObserver(PrReviewReminderSchedulerService);
+    this.bind(WORKSPACE_AUTHORIZER)
+      .toProvider(WorkspaceAuthorizerProvider)
+      .tag(AuthorizationTags.AUTHORIZER);
 
     this.projectRoot = __dirname;
     // Customize @loopback/boot Booter Conventions here
@@ -101,6 +80,11 @@ export class RestApi extends BootMixin(
         // Customize ControllerBooter Conventions here
         dirs: ['controllers'],
         extensions: ['.controller.js'],
+        nested: true,
+      },
+      services: {
+        dirs: ['services'],
+        extensions: ['.service.js'],
         nested: true,
       },
     };

--- a/api/src/authorization/workspace-authorizer.provider.ts
+++ b/api/src/authorization/workspace-authorizer.provider.ts
@@ -1,0 +1,89 @@
+import {Provider, service} from '@loopback/core';
+import {
+  AuthorizationContext,
+  AuthorizationDecision,
+  AuthorizationMetadata,
+  Authorizer,
+} from '@loopback/authorization';
+import {securityId, UserProfile} from '@loopback/security';
+import {WORKSPACE_PERMISSION, WorkspacePermission} from '../constants';
+import {WorkspaceAuthorizationService} from '../services';
+
+export const WORKSPACE_AUTHORIZER =
+  'authorizationProviders.workspace-authorizer';
+
+const KNOWN_PERMISSIONS = new Set<string>(Object.values(WORKSPACE_PERMISSION));
+
+export class WorkspaceAuthorizerProvider implements Provider<Authorizer> {
+  constructor(
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  value(): Authorizer {
+    return this.authorize.bind(this);
+  }
+
+  async authorize(
+    authorizationContext: AuthorizationContext,
+    metadata: AuthorizationMetadata,
+  ): Promise<AuthorizationDecision> {
+    const permission = metadata.resource;
+
+    if (!permission || !KNOWN_PERMISSIONS.has(permission)) {
+      return AuthorizationDecision.ABSTAIN;
+    }
+
+    const principal = authorizationContext.principals[0];
+    const principalProfile = principal as unknown as UserProfile | undefined;
+    const rawUserId = principal?.id ?? principalProfile?.[securityId];
+    const userId =
+      typeof rawUserId === 'number'
+        ? rawUserId
+        : Number.parseInt(String(rawUserId), 10);
+    const workspaceId = this.getWorkspaceId(authorizationContext);
+
+    if (!Number.isFinite(userId) || !Number.isFinite(workspaceId)) {
+      return AuthorizationDecision.DENY;
+    }
+
+    const decision = await this.workspaceAuthorizationService.checkPermission(
+      workspaceId,
+      userId,
+      permission as WorkspacePermission,
+    );
+
+    return decision.allowed
+      ? AuthorizationDecision.ALLOW
+      : AuthorizationDecision.DENY;
+  }
+
+  private getWorkspaceId(authorizationContext: AuthorizationContext): number {
+    for (const arg of authorizationContext.invocationContext.args) {
+      if (typeof arg === 'number') {
+        return arg;
+      }
+
+      if (typeof arg === 'string') {
+        const parsed = Number.parseInt(arg, 10);
+
+        if (Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+
+      if (arg && typeof arg === 'object' && 'workspaceId' in arg) {
+        const parsed = Number.parseInt(
+          String((arg as {workspaceId?: unknown}).workspaceId),
+          10,
+        );
+
+        if (Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+    }
+
+    return Number.NaN;
+  }
+}

--- a/api/src/constants/system/index.ts
+++ b/api/src/constants/system/index.ts
@@ -1,1 +1,2 @@
 export * from './workspace-member.const';
+export * from './workspace-permission.const';

--- a/api/src/constants/system/workspace-permission.const.ts
+++ b/api/src/constants/system/workspace-permission.const.ts
@@ -1,0 +1,24 @@
+export const WORKSPACE_PERMISSION = {
+  WORKSPACE_VIEW: 'workspace.view',
+  WORKSPACE_SETTINGS_MANAGE: 'workspace.settings.manage',
+  WORKSPACE_MEMBERS_MANAGE: 'workspace.members.manage',
+  WORKSPACE_DELETE: 'workspace.delete',
+  GITHUB_INSTALL_MANAGE: 'github.install.manage',
+  GITHUB_ISSUE_MANAGE: 'github.issue.manage',
+  GITHUB_PULL_REQUEST_VIEW: 'github.pull-request.view',
+  AI_SETTINGS_MANAGE: 'ai.settings.manage',
+  CAPACITY_PLAN_MANAGE: 'capacity-plan.manage',
+  COMMUNICATION_VIEW: 'communication.view',
+} as const;
+
+export type WorkspacePermission =
+  (typeof WORKSPACE_PERMISSION)[keyof typeof WORKSPACE_PERMISSION];
+
+export const WORKSPACE_ROLE = {
+  OWNER: 'OWNER',
+  ADMIN: 'ADMIN',
+  MEMBER: 'MEMBER',
+} as const;
+
+export type WorkspaceRole =
+  (typeof WORKSPACE_ROLE)[keyof typeof WORKSPACE_ROLE];

--- a/api/src/controllers/auth/user.controller.ts
+++ b/api/src/controllers/auth/user.controller.ts
@@ -1,20 +1,82 @@
-import {repository} from '@loopback/repository';
-import {UserRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept} from '@loopback/core';
+import {Count, Filter, Where, repository} from '@loopback/repository';
+import {get, HttpErrors, param, post} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {User, UserRelations} from '../../models';
-import {post} from '@loopback/rest';
+import {
+  UserRepository,
+  WorkspaceMemberRepository,
+  WorkspaceRepository,
+} from '../../repositories';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const UserBaseCrudController = createBaseCrudController<
-  User,
-  typeof User.prototype.id,
-  UserRelations
->('/users');
-
-export class UserController extends UserBaseCrudController {
+@authenticate('jwt-header')
+export class UserController {
   constructor(
-    @repository(UserRepository) private userRepository: UserRepository,
-  ) {
-    super(userRepository);
+    @repository(UserRepository)
+    private userRepository: UserRepository,
+    @repository(WorkspaceRepository)
+    private workspaceRepository: WorkspaceRepository,
+    @repository(WorkspaceMemberRepository)
+    private workspaceMemberRepository: WorkspaceMemberRepository,
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/users')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<User>,
+  ): Promise<User[]> {
+    const scopedFilter = await this.scopeUserFilter(userProfile, filter);
+
+    return this.userRepository.find(scopedFilter);
+  }
+
+  @get('/users/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<User>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeUserFilter(userProfile, {where});
+
+    return this.userRepository.count(scopedFilter.where);
+  }
+
+  @get('/users/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<User> {
+    await this.assertCanViewUser(userProfile, id);
+
+    return this.userRepository.findById(id);
+  }
+
+  @get('/Users/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof UserRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<UserRelations[K]> {
+    await this.assertCanViewUser(userProfile, id);
+
+    const entity: User & UserRelations = await this.userRepository.findById(
+      id,
+      {
+        include: [relationName as string],
+      },
+    );
+
+    return entity[relationName];
   }
 
   @post('/users/deleteProfile')
@@ -22,5 +84,58 @@ export class UserController extends UserBaseCrudController {
     return {
       message: 'Not implemented',
     };
+  }
+
+  private async scopeUserFilter(
+    userProfile: UserProfile,
+    filter: Filter<User> | undefined,
+  ): Promise<Filter<User>> {
+    const userIds = await this.accessibleUserIds(userProfile);
+    const accessWhere: Where<User> = {id: {inq: userIds}};
+
+    return {
+      ...filter,
+      where: filter?.where ? {and: [filter.where, accessWhere]} : accessWhere,
+    };
+  }
+
+  private async assertCanViewUser(
+    userProfile: UserProfile,
+    requestedUserId: number,
+  ): Promise<void> {
+    const userIds = await this.accessibleUserIds(userProfile);
+
+    if (!userIds.includes(requestedUserId)) {
+      throw new HttpErrors.Forbidden('You do not have access to this user.');
+    }
+  }
+
+  private async accessibleUserIds(userProfile: UserProfile): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const ownedWorkspaces = await this.workspaceRepository.find({
+      where: {ownerId: userId},
+    });
+    const allWorkspaceIds = Array.from(
+      new Set([
+        ...workspaceIds,
+        ...ownedWorkspaces.map(workspace => workspace.id),
+      ]),
+    );
+    const members = await this.workspaceMemberRepository.find({
+      where: {workspaceId: {inq: allWorkspaceIds}},
+    });
+
+    return Array.from(
+      new Set(
+        [
+          userId,
+          ...ownedWorkspaces.map(workspace => workspace.ownerId),
+          ...members.map(member => member.userId),
+        ].filter((id): id is number => typeof id === 'number'),
+      ),
+    );
   }
 }

--- a/api/src/controllers/github-integration/github.controller.ts
+++ b/api/src/controllers/github-integration/github.controller.ts
@@ -1,16 +1,52 @@
+import {authenticate} from '@loopback/authentication';
 import {inject, service} from '@loopback/core';
-import {get, param, Response, RestBindings} from '@loopback/rest';
-import {GithubService} from '../../services/github-integration/github.service';
+import {get, HttpErrors, param, Response, RestBindings} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {WORKSPACE_PERMISSION} from '../../constants';
+import {GithubService, WorkspaceAuthorizationService} from '../../services';
 
 export class GithubController {
-  constructor(@service(GithubService) private githubService: GithubService) {}
+  constructor(
+    @service(GithubService)
+    private githubService: GithubService,
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
 
   @get('/github/installApp')
+  @authenticate('jwt-query')
   async installGithubApp(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @inject(RestBindings.Http.RESPONSE) response: Response,
     @param.query.string('workspaceId') workspaceId?: string,
   ) {
-    const url = await this.githubService.getInstallationUrl(workspaceId);
+    if (!workspaceId) {
+      throw new HttpErrors.BadRequest(
+        'The "workspaceId" query parameter is required.',
+      );
+    }
+
+    const normalizedWorkspaceId = Number.parseInt(workspaceId, 10);
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    if (!Number.isFinite(normalizedWorkspaceId)) {
+      throw new HttpErrors.BadRequest(
+        'The "workspaceId" query parameter must be a number.',
+      );
+    }
+
+    await this.workspaceAuthorizationService.assertPermission(
+      normalizedWorkspaceId,
+      userId,
+      WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE,
+    );
+
+    const url = await this.githubService.getInstallationUrl({
+      workspaceId: normalizedWorkspaceId,
+      userId,
+    });
     return response.redirect(url);
   }
 

--- a/api/src/controllers/github/issue.controller.ts
+++ b/api/src/controllers/github/issue.controller.ts
@@ -1,7 +1,28 @@
-import {service} from '@loopback/core';
-import {Count, repository, Where} from '@loopback/repository';
-import {del, HttpErrors, param, post, requestBody} from '@loopback/rest';
-import {GithubIssue, GithubIssueRelations} from '../../models';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  HttpErrors,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {
+  GithubIssue,
+  GithubIssueRelations,
+  GithubRepository,
+} from '../../models';
 import {
   GithubIssueRepository,
   GithubRepositoryRepository,
@@ -13,16 +34,11 @@ import {
   IssueService,
   type IssuePriorityPrediction,
   QueueService,
+  WorkspaceAuthorizationService,
 } from '../../services';
-import {createBaseCrudController} from '../base-crud.controller';
 
-const GithubIssueBaseCrudController = createBaseCrudController<
-  GithubIssue,
-  typeof GithubIssue.prototype.id,
-  GithubIssueRelations
->('/githubIssues');
-
-export class GithubIssueController extends GithubIssueBaseCrudController {
+@authenticate('jwt-header')
+export class GithubIssueController {
   constructor(
     @repository(GithubIssueRepository)
     private githubIssueRepository: GithubIssueRepository,
@@ -38,24 +54,154 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
     private issueService: IssueService,
     @service(QueueService)
     private queueService: QueueService,
-  ) {
-    super(githubIssueRepository);
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/githubIssues')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<GithubIssue>,
+  ): Promise<GithubIssue[]> {
+    const scopedFilter = await this.scopeIssueFilter(userProfile, filter);
+
+    return this.githubIssueRepository.find(scopedFilter);
+  }
+
+  @get('/githubIssues/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<GithubIssue>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeIssueFilter(userProfile, {where});
+
+    return this.githubIssueRepository.count(scopedFilter.where);
+  }
+
+  @get('/githubIssues/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<GithubIssue> {
+    const issue = await this.githubIssueRepository.findById(id);
+    await this.assertCanViewIssue(userProfile, issue);
+
+    return issue;
+  }
+
+  @get('/GithubIssues/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof GithubIssueRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<GithubIssueRelations[K]> {
+    const issue = await this.githubIssueRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewIssue(userProfile, issue);
+
+    return (issue as GithubIssue & GithubIssueRelations)[relationName];
+  }
+
+  @post('/githubIssues')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubIssue>,
+  ): Promise<GithubIssue> {
+    await this.assertCanUseRepository(userProfile, data.repositoryId);
+
+    return this.githubIssueRepository.create(data);
+  }
+
+  @patch('/githubIssues/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubIssue>,
+  ): Promise<void> {
+    const issue = await this.githubIssueRepository.findById(id);
+    await this.assertCanUseRepository(userProfile, issue.repositoryId);
+
+    return this.githubIssueRepository.updateById(id, data);
+  }
+
+  @put('/githubIssues/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubIssue>,
+  ): Promise<void> {
+    const issue = await this.githubIssueRepository.findById(id);
+    await this.assertCanUseRepository(userProfile, issue.repositoryId);
+
+    return this.githubIssueRepository.replaceById(id, data);
   }
 
   @del('/githubIssues/{id}')
-  public async deleteById(@param.path.number('id') id: number): Promise<void> {
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const issue = await this.githubIssueRepository.findById(id);
+    const repository = await this.githubRepositoryRepository.findById(
+      issue.repositoryId,
+    );
+    await this.assertCanManageWorkspace(userProfile, repository.workspaceId);
+
     await this.issueService.deleteById(id);
   }
 
   @del('/githubIssues')
-  public async deleteAll(
-    @param.query.object('where') where: Where<GithubIssue>,
-  ): Promise<Count> {
-    return this.issueService.deleteAll(where);
+  public async deleteAll(): Promise<Count> {
+    return {count: 0};
   }
 
   @post('/githubIssues/analyzePriority')
   public async analyzePriority(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @requestBody()
     body: {
       repositoryId: number;
@@ -66,6 +212,7 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
     const {title, description} = this.validateDraft(body);
 
     const repositoryContext = await this.getRepositoryContext(
+      userProfile,
       body.repositoryId,
     );
 
@@ -79,21 +226,29 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
 
   @post('/githubIssues/createWithPriority')
   public async createWithPriority(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @requestBody()
     body: {
       repositoryId: number;
       title: string;
       description: string | null;
+      prediction?: IssuePriorityPrediction | null;
     },
   ): Promise<{
     queued: true;
   }> {
     const {title, description} = this.validateDraft(body);
-    await this.getRepositoryContext(body.repositoryId);
+    await this.getRepositoryContext(userProfile, body.repositoryId);
+    const prediction = this.issuePriorityService.normalizePredictionInput(
+      body.prediction,
+    );
+
     await this.queueService.enqueueGithubIssueCreation({
       repositoryId: body.repositoryId,
       title,
       description,
+      prediction,
     });
 
     return {
@@ -125,12 +280,17 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
     };
   }
 
-  private async getRepositoryContext(repositoryId: number): Promise<{
+  private async getRepositoryContext(
+    userProfile: UserProfile,
+    repositoryId: number,
+  ): Promise<{
     installationId: number;
-    repository: Awaited<ReturnType<GithubRepositoryRepository['findById']>>;
+    repository: GithubRepository;
   }> {
     const repository =
       await this.githubRepositoryRepository.findById(repositoryId);
+    await this.assertCanUseRepository(userProfile, repository.id);
+
     const workspace = await this.workspaceRepository.findById(
       repository.workspaceId,
     );
@@ -146,5 +306,72 @@ export class GithubIssueController extends GithubIssueBaseCrudController {
       installationId,
       repository,
     };
+  }
+
+  private async scopeIssueFilter(
+    userProfile: UserProfile,
+    filter: Filter<GithubIssue> | undefined,
+  ): Promise<Filter<GithubIssue>> {
+    const repositoryIds = await this.accessibleRepositoryIds(userProfile);
+    const repositoryWhere: Where<GithubIssue> = {
+      repositoryId: {inq: repositoryIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, repositoryWhere]}
+        : repositoryWhere,
+    };
+  }
+
+  private async accessibleRepositoryIds(
+    userProfile: UserProfile,
+  ): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const repositories = await this.githubRepositoryRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+
+    return repositories.map(repository => repository.id);
+  }
+
+  private async assertCanViewIssue(
+    userProfile: UserProfile,
+    issue: GithubIssue,
+  ): Promise<void> {
+    await this.assertCanUseRepository(userProfile, issue.repositoryId);
+  }
+
+  private async assertCanUseRepository(
+    userProfile: UserProfile,
+    repositoryId: number | undefined,
+  ): Promise<void> {
+    const repository = await this.githubRepositoryRepository.findById(
+      Number(repositoryId),
+    );
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      repository.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageWorkspace(
+    userProfile: UserProfile,
+    workspaceId: number,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/github/pull-request.controller.ts
+++ b/api/src/controllers/github/pull-request.controller.ts
@@ -1,36 +1,223 @@
-import {service} from '@loopback/core';
-import {Count, repository, Where} from '@loopback/repository';
-import {del, param} from '@loopback/rest';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {GithubPullRequest, GithubPullRequestRelations} from '../../models';
-import {GithubPullRequestRepository} from '../../repositories';
-import {PullRequestService} from '../../services';
-import {createBaseCrudController} from '../base-crud.controller';
+import {
+  GithubPullRequestRepository,
+  GithubRepositoryRepository,
+} from '../../repositories';
+import {
+  PullRequestService,
+  WorkspaceAuthorizationService,
+} from '../../services';
 
-const GithubPullRequestBaseCrudController = createBaseCrudController<
-  GithubPullRequest,
-  typeof GithubPullRequest.prototype.id,
-  GithubPullRequestRelations
->('/githubPullRequests');
-
-export class GithubPullRequestController extends GithubPullRequestBaseCrudController {
+@authenticate('jwt-header')
+export class GithubPullRequestController {
   constructor(
     @repository(GithubPullRequestRepository)
     private githubPullRequestRepository: GithubPullRequestRepository,
+    @repository(GithubRepositoryRepository)
+    private githubRepositoryRepository: GithubRepositoryRepository,
     @service(PullRequestService)
     private pullRequestService: PullRequestService,
-  ) {
-    super(githubPullRequestRepository);
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/githubPullRequests')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<GithubPullRequest>,
+  ): Promise<GithubPullRequest[]> {
+    const scopedFilter = await this.scopePullRequestFilter(userProfile, filter);
+
+    return this.githubPullRequestRepository.find(scopedFilter);
+  }
+
+  @get('/githubPullRequests/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<GithubPullRequest>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopePullRequestFilter(userProfile, {
+      where,
+    });
+
+    return this.githubPullRequestRepository.count(scopedFilter.where);
+  }
+
+  @get('/githubPullRequests/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<GithubPullRequest> {
+    const pullRequest = await this.githubPullRequestRepository.findById(id);
+    await this.assertCanViewPullRequest(userProfile, pullRequest);
+
+    return pullRequest;
+  }
+
+  @get('/GithubPullRequests/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof GithubPullRequestRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<GithubPullRequestRelations[K]> {
+    const pullRequest = await this.githubPullRequestRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewPullRequest(userProfile, pullRequest);
+
+    return (pullRequest as GithubPullRequest & GithubPullRequestRelations)[
+      relationName
+    ];
+  }
+
+  @patch('/githubPullRequests/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubPullRequest>,
+  ): Promise<void> {
+    const pullRequest = await this.githubPullRequestRepository.findById(id);
+    await this.assertCanUseRepository(userProfile, pullRequest.repositoryId);
+
+    return this.githubPullRequestRepository.updateById(id, data);
+  }
+
+  @put('/githubPullRequests/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubPullRequest>,
+  ): Promise<void> {
+    const pullRequest = await this.githubPullRequestRepository.findById(id);
+    await this.assertCanUseRepository(userProfile, pullRequest.repositoryId);
+
+    return this.githubPullRequestRepository.replaceById(id, data);
   }
 
   @del('/githubPullRequests/{id}')
-  public async deleteById(@param.path.number('id') id: number): Promise<void> {
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const pullRequest = await this.githubPullRequestRepository.findById(id);
+    const repository = await this.githubRepositoryRepository.findById(
+      pullRequest.repositoryId,
+    );
+    await this.assertCanManageWorkspace(userProfile, repository.workspaceId);
+
     await this.pullRequestService.deleteById(id);
   }
 
   @del('/githubPullRequests')
-  public async deleteAll(
-    @param.query.object('where') where: Where<GithubPullRequest>,
-  ): Promise<Count> {
-    return this.pullRequestService.deleteAll(where);
+  public async deleteAll(): Promise<Count> {
+    return {count: 0};
+  }
+
+  private async scopePullRequestFilter(
+    userProfile: UserProfile,
+    filter: Filter<GithubPullRequest> | undefined,
+  ): Promise<Filter<GithubPullRequest>> {
+    const repositoryIds = await this.accessibleRepositoryIds(userProfile);
+    const repositoryWhere: Where<GithubPullRequest> = {
+      repositoryId: {inq: repositoryIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, repositoryWhere]}
+        : repositoryWhere,
+    };
+  }
+
+  private async accessibleRepositoryIds(
+    userProfile: UserProfile,
+  ): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const repositories = await this.githubRepositoryRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+
+    return repositories.map(repository => repository.id);
+  }
+
+  private async assertCanViewPullRequest(
+    userProfile: UserProfile,
+    pullRequest: GithubPullRequest,
+  ): Promise<void> {
+    await this.assertCanUseRepository(userProfile, pullRequest.repositoryId);
+  }
+
+  private async assertCanUseRepository(
+    userProfile: UserProfile,
+    repositoryId: number | undefined,
+  ): Promise<void> {
+    const repository = await this.githubRepositoryRepository.findById(
+      Number(repositoryId),
+    );
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      repository.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageWorkspace(
+    userProfile: UserProfile,
+    workspaceId: number,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/github/repository.controller.ts
+++ b/api/src/controllers/github/repository.controller.ts
@@ -1,19 +1,204 @@
-import {repository} from '@loopback/repository';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {GithubRepository, GithubRepositoryRelations} from '../../models';
 import {GithubRepositoryRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const GithubRepositoryBaseCrudController = createBaseCrudController<
-  GithubRepository,
-  typeof GithubRepository.prototype.id,
-  GithubRepositoryRelations
->('/githubRepositories');
-
-export class GithubRepositoryController extends GithubRepositoryBaseCrudController {
+@authenticate('jwt-header')
+export class GithubRepositoryController {
   constructor(
     @repository(GithubRepositoryRepository)
     private githubRepositoryRepository: GithubRepositoryRepository,
-  ) {
-    super(githubRepositoryRepository);
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/githubRepositories')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<GithubRepository>,
+  ): Promise<GithubRepository[]> {
+    const scopedFilter = await this.scopeRepositoryFilter(userProfile, filter);
+
+    return this.githubRepositoryRepository.find(scopedFilter);
+  }
+
+  @get('/githubRepositories/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<GithubRepository>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeRepositoryFilter(userProfile, {where});
+
+    return this.githubRepositoryRepository.count(scopedFilter.where);
+  }
+
+  @get('/githubRepositories/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<GithubRepository> {
+    const repository = await this.githubRepositoryRepository.findById(id);
+    await this.assertCanViewRepository(userProfile, repository);
+
+    return repository;
+  }
+
+  @get('/GithubRepositories/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof GithubRepositoryRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<GithubRepositoryRelations[K]> {
+    const repository = await this.githubRepositoryRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewRepository(userProfile, repository);
+
+    return (repository as GithubRepository & GithubRepositoryRelations)[
+      relationName
+    ];
+  }
+
+  @post('/githubRepositories')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubRepository>,
+  ): Promise<GithubRepository> {
+    await this.assertCanManageRepository(userProfile, data.workspaceId);
+
+    return this.githubRepositoryRepository.create(data);
+  }
+
+  @patch('/githubRepositories/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubRepository>,
+  ): Promise<void> {
+    const repository = await this.githubRepositoryRepository.findById(id);
+    await this.assertCanManageRepository(userProfile, repository.workspaceId);
+
+    return this.githubRepositoryRepository.updateById(id, data);
+  }
+
+  @put('/githubRepositories/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<GithubRepository>,
+  ): Promise<void> {
+    const repository = await this.githubRepositoryRepository.findById(id);
+    await this.assertCanManageRepository(userProfile, repository.workspaceId);
+
+    return this.githubRepositoryRepository.replaceById(id, data);
+  }
+
+  @del('/githubRepositories/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const repository = await this.githubRepositoryRepository.findById(id);
+    await this.assertCanManageRepository(userProfile, repository.workspaceId);
+
+    return this.githubRepositoryRepository.deleteCascade(id);
+  }
+
+  private async scopeRepositoryFilter(
+    userProfile: UserProfile,
+    filter: Filter<GithubRepository> | undefined,
+  ): Promise<Filter<GithubRepository>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const workspaceWhere: Where<GithubRepository> = {
+      workspaceId: {inq: workspaceIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, workspaceWhere]}
+        : workspaceWhere,
+    };
+  }
+
+  private async assertCanViewRepository(
+    userProfile: UserProfile,
+    repository: GithubRepository,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      repository.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageRepository(
+    userProfile: UserProfile,
+    workspaceId: number | undefined,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      Number(workspaceId),
+      userId,
+    );
   }
 }

--- a/api/src/controllers/planning/capacity-plan-entry.controller.ts
+++ b/api/src/controllers/planning/capacity-plan-entry.controller.ts
@@ -1,19 +1,236 @@
-import {repository} from '@loopback/repository';
-import {CapacityPlanEntry, CapacityPlanEntryRelations} from '../../models';
-import {CapacityPlanEntryRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
-
-const CapacityPlanEntryBaseCrudController = createBaseCrudController<
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {
+  CapacityPlan,
   CapacityPlanEntry,
-  typeof CapacityPlanEntry.prototype.id,
-  CapacityPlanEntryRelations
->('capacityPlanEntries');
+  CapacityPlanEntryRelations,
+} from '../../models';
+import {
+  CapacityPlanEntryRepository,
+  CapacityPlanRepository,
+} from '../../repositories';
+import {WorkspaceAuthorizationService} from '../../services';
 
-export class CapacityPlanEntryController extends CapacityPlanEntryBaseCrudController {
+@authenticate('jwt-header')
+export class CapacityPlanEntryController {
   constructor(
     @repository(CapacityPlanEntryRepository)
     private capacityPlanEntryRepository: CapacityPlanEntryRepository,
-  ) {
-    super(capacityPlanEntryRepository);
+    @repository(CapacityPlanRepository)
+    private capacityPlanRepository: CapacityPlanRepository,
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/capacityPlanEntries')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<CapacityPlanEntry>,
+  ): Promise<CapacityPlanEntry[]> {
+    const scopedFilter = await this.scopeEntryFilter(userProfile, filter);
+
+    return this.capacityPlanEntryRepository.find(scopedFilter);
+  }
+
+  @get('/capacityPlanEntries/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<CapacityPlanEntry>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeEntryFilter(userProfile, {where});
+
+    return this.capacityPlanEntryRepository.count(scopedFilter.where);
+  }
+
+  @get('/capacityPlanEntries/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<CapacityPlanEntry> {
+    const entry = await this.capacityPlanEntryRepository.findById(id);
+    await this.assertCanViewEntry(userProfile, entry);
+
+    return entry;
+  }
+
+  @get('/CapacityPlanEntries/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof CapacityPlanEntryRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<CapacityPlanEntryRelations[K]> {
+    const entry = await this.capacityPlanEntryRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewEntry(userProfile, entry);
+
+    return (entry as CapacityPlanEntry & CapacityPlanEntryRelations)[
+      relationName
+    ];
+  }
+
+  @post('/capacityPlanEntries')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlanEntry>,
+  ): Promise<CapacityPlanEntry> {
+    await this.assertCanManagePlan(userProfile, Number(data.capacityPlanId));
+
+    return this.capacityPlanEntryRepository.create(data);
+  }
+
+  @patch('/capacityPlanEntries/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlanEntry>,
+  ): Promise<void> {
+    const entry = await this.capacityPlanEntryRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, entry.capacityPlanId);
+
+    return this.capacityPlanEntryRepository.updateById(id, data);
+  }
+
+  @put('/capacityPlanEntries/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlanEntry>,
+  ): Promise<void> {
+    const entry = await this.capacityPlanEntryRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, entry.capacityPlanId);
+
+    return this.capacityPlanEntryRepository.replaceById(id, data);
+  }
+
+  @del('/capacityPlanEntries/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const entry = await this.capacityPlanEntryRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, entry.capacityPlanId);
+
+    return this.capacityPlanEntryRepository.deleteById(id);
+  }
+
+  private async scopeEntryFilter(
+    userProfile: UserProfile,
+    filter: Filter<CapacityPlanEntry> | undefined,
+  ): Promise<Filter<CapacityPlanEntry>> {
+    const capacityPlanIds = await this.accessibleCapacityPlanIds(userProfile);
+    const capacityPlanWhere: Where<CapacityPlanEntry> = {
+      capacityPlanId: {inq: capacityPlanIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, capacityPlanWhere]}
+        : capacityPlanWhere,
+    };
+  }
+
+  private async accessibleCapacityPlanIds(
+    userProfile: UserProfile,
+  ): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const capacityPlans = await this.capacityPlanRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+
+    return capacityPlans.map(plan => plan.id);
+  }
+
+  private async assertCanViewEntry(
+    userProfile: UserProfile,
+    entry: CapacityPlanEntry,
+  ): Promise<void> {
+    const capacityPlan = await this.capacityPlanRepository.findById(
+      entry.capacityPlanId,
+    );
+    await this.assertCanViewPlan(userProfile, capacityPlan);
+  }
+
+  private async assertCanViewPlan(
+    userProfile: UserProfile,
+    capacityPlan: CapacityPlan,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      capacityPlan.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManagePlan(
+    userProfile: UserProfile,
+    capacityPlanId: number,
+  ): Promise<void> {
+    const capacityPlan =
+      await this.capacityPlanRepository.findById(capacityPlanId);
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      capacityPlan.workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/planning/capacity-plan.controller.ts
+++ b/api/src/controllers/planning/capacity-plan.controller.ts
@@ -1,19 +1,207 @@
-import {repository} from '@loopback/repository';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {CapacityPlan, CapacityPlanRelations} from '../../models';
 import {CapacityPlanRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const CapacityPlanBaseCrudController = createBaseCrudController<
-  CapacityPlan,
-  typeof CapacityPlan.prototype.id,
-  CapacityPlanRelations
->('capacityPlans');
-
-export class CapacityPlanController extends CapacityPlanBaseCrudController {
+@authenticate('jwt-header')
+export class CapacityPlanController {
   constructor(
     @repository(CapacityPlanRepository)
     private capacityPlanRepository: CapacityPlanRepository,
-  ) {
-    super(capacityPlanRepository);
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/capacityPlans')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<CapacityPlan>,
+  ): Promise<CapacityPlan[]> {
+    const scopedFilter = await this.scopeCapacityPlanFilter(
+      userProfile,
+      filter,
+    );
+
+    return this.capacityPlanRepository.find(scopedFilter);
+  }
+
+  @get('/capacityPlans/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<CapacityPlan>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeCapacityPlanFilter(userProfile, {
+      where,
+    });
+
+    return this.capacityPlanRepository.count(scopedFilter.where);
+  }
+
+  @get('/capacityPlans/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<CapacityPlan> {
+    const capacityPlan = await this.capacityPlanRepository.findById(id);
+    await this.assertCanViewPlan(userProfile, capacityPlan);
+
+    return capacityPlan;
+  }
+
+  @get('/CapacityPlans/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof CapacityPlanRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<CapacityPlanRelations[K]> {
+    const capacityPlan = await this.capacityPlanRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewPlan(userProfile, capacityPlan);
+
+    return (capacityPlan as CapacityPlan & CapacityPlanRelations)[relationName];
+  }
+
+  @post('/capacityPlans')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlan>,
+  ): Promise<CapacityPlan> {
+    await this.assertCanManageWorkspace(userProfile, data.workspaceId);
+
+    return this.capacityPlanRepository.create(data);
+  }
+
+  @patch('/capacityPlans/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlan>,
+  ): Promise<void> {
+    const capacityPlan = await this.capacityPlanRepository.findById(id);
+    await this.assertCanManageWorkspace(userProfile, capacityPlan.workspaceId);
+
+    return this.capacityPlanRepository.updateById(id, data);
+  }
+
+  @put('/capacityPlans/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<CapacityPlan>,
+  ): Promise<void> {
+    const capacityPlan = await this.capacityPlanRepository.findById(id);
+    await this.assertCanManageWorkspace(userProfile, capacityPlan.workspaceId);
+
+    return this.capacityPlanRepository.replaceById(id, data);
+  }
+
+  @del('/capacityPlans/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const capacityPlan = await this.capacityPlanRepository.findById(id);
+    await this.assertCanManageWorkspace(userProfile, capacityPlan.workspaceId);
+
+    return this.capacityPlanRepository.deleteById(id);
+  }
+
+  private async scopeCapacityPlanFilter(
+    userProfile: UserProfile,
+    filter: Filter<CapacityPlan> | undefined,
+  ): Promise<Filter<CapacityPlan>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const workspaceWhere: Where<CapacityPlan> = {
+      workspaceId: {inq: workspaceIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, workspaceWhere]}
+        : workspaceWhere,
+    };
+  }
+
+  private async assertCanViewPlan(
+    userProfile: UserProfile,
+    capacityPlan: CapacityPlan,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      capacityPlan.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageWorkspace(
+    userProfile: UserProfile,
+    workspaceId: number | undefined,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      Number(workspaceId),
+      userId,
+    );
   }
 }

--- a/api/src/controllers/planning/issue-assignment.controller.ts
+++ b/api/src/controllers/planning/issue-assignment.controller.ts
@@ -1,33 +1,101 @@
-import {service} from '@loopback/core';
-import {DataObject} from '@loopback/repository';
-import {repository} from '@loopback/repository';
-import {intercept} from '@loopback/core';
-import {post, requestBody} from '@loopback/rest';
-import {IssueAssignment, IssueAssignmentRelations} from '../../models';
-import {IssueAssignmentRepository} from '../../repositories';
-import {CapacityPlanningSyncService} from '../../services/capacity-planning-sync.service';
-import {createBaseCrudController} from '../base-crud.controller';
-
-const IssueAssignmentBaseCrudController = createBaseCrudController<
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {
+  CapacityPlan,
   IssueAssignment,
-  typeof IssueAssignment.prototype.id,
-  IssueAssignmentRelations
->('issueAssignments');
+  IssueAssignmentRelations,
+} from '../../models';
+import {
+  CapacityPlanRepository,
+  IssueAssignmentRepository,
+} from '../../repositories';
+import {
+  CapacityPlanningSyncService,
+  WorkspaceAuthorizationService,
+} from '../../services';
 
-export class IssueAssignmentController extends IssueAssignmentBaseCrudController {
+@authenticate('jwt-header')
+export class IssueAssignmentController {
   constructor(
     @repository(IssueAssignmentRepository)
     private issueAssignmentRepository: IssueAssignmentRepository,
+    @repository(CapacityPlanRepository)
+    private capacityPlanRepository: CapacityPlanRepository,
     @service(CapacityPlanningSyncService)
     private capacityPlanningSyncService: CapacityPlanningSyncService,
-  ) {
-    super(issueAssignmentRepository);
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/issueAssignments')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<IssueAssignment>,
+  ): Promise<IssueAssignment[]> {
+    const scopedFilter = await this.scopeAssignmentFilter(userProfile, filter);
+
+    return this.issueAssignmentRepository.find(scopedFilter);
+  }
+
+  @get('/issueAssignments/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<IssueAssignment>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeAssignmentFilter(userProfile, {where});
+
+    return this.issueAssignmentRepository.count(scopedFilter.where);
+  }
+
+  @get('/issueAssignments/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<IssueAssignment> {
+    const assignment = await this.issueAssignmentRepository.findById(id);
+    await this.assertCanViewAssignment(userProfile, assignment);
+
+    return assignment;
+  }
+
+  @get('/IssueAssignments/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof IssueAssignmentRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<IssueAssignmentRelations[K]> {
+    const assignment = await this.issueAssignmentRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewAssignment(userProfile, assignment);
+
+    return (assignment as IssueAssignment & IssueAssignmentRelations)[
+      relationName
+    ];
   }
 
   @post('/issueAssignments')
   @intercept('interceptors.json-api-deserializer')
   @intercept('interceptors.json-api-serializer')
-  override async create(
+  async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @requestBody({
       content: {
         'application/vnd.api+json': {
@@ -39,6 +107,7 @@ export class IssueAssignmentController extends IssueAssignmentBaseCrudController
     })
     data: DataObject<IssueAssignment>,
   ): Promise<IssueAssignment> {
+    await this.assertCanManagePlan(userProfile, Number(data.capacityPlanId));
     const createdAssignment = await this.issueAssignmentRepository.create(data);
 
     try {
@@ -53,5 +122,132 @@ export class IssueAssignmentController extends IssueAssignmentBaseCrudController
     }
 
     return createdAssignment;
+  }
+
+  @patch('/issueAssignments/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<IssueAssignment>,
+  ): Promise<void> {
+    const assignment = await this.issueAssignmentRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, assignment.capacityPlanId);
+
+    return this.issueAssignmentRepository.updateById(id, data);
+  }
+
+  @put('/issueAssignments/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<IssueAssignment>,
+  ): Promise<void> {
+    const assignment = await this.issueAssignmentRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, assignment.capacityPlanId);
+
+    return this.issueAssignmentRepository.replaceById(id, data);
+  }
+
+  @del('/issueAssignments/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const assignment = await this.issueAssignmentRepository.findById(id);
+    await this.assertCanManagePlan(userProfile, assignment.capacityPlanId);
+
+    return this.issueAssignmentRepository.deleteById(id);
+  }
+
+  private async scopeAssignmentFilter(
+    userProfile: UserProfile,
+    filter: Filter<IssueAssignment> | undefined,
+  ): Promise<Filter<IssueAssignment>> {
+    const capacityPlanIds = await this.accessibleCapacityPlanIds(userProfile);
+    const capacityPlanWhere: Where<IssueAssignment> = {
+      capacityPlanId: {inq: capacityPlanIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, capacityPlanWhere]}
+        : capacityPlanWhere,
+    };
+  }
+
+  private async accessibleCapacityPlanIds(
+    userProfile: UserProfile,
+  ): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const capacityPlans = await this.capacityPlanRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+
+    return capacityPlans.map(plan => plan.id);
+  }
+
+  private async assertCanViewAssignment(
+    userProfile: UserProfile,
+    assignment: IssueAssignment,
+  ): Promise<void> {
+    const capacityPlan = await this.capacityPlanRepository.findById(
+      assignment.capacityPlanId,
+    );
+    await this.assertCanViewPlan(userProfile, capacityPlan);
+  }
+
+  private async assertCanViewPlan(
+    userProfile: UserProfile,
+    capacityPlan: CapacityPlan,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      capacityPlan.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManagePlan(
+    userProfile: UserProfile,
+    capacityPlanId: number,
+  ): Promise<void> {
+    const capacityPlan =
+      await this.capacityPlanRepository.findById(capacityPlanId);
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      capacityPlan.workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/authorization.controller.ts
+++ b/api/src/controllers/system/authorization.controller.ts
@@ -1,0 +1,66 @@
+import {authenticate} from '@loopback/authentication';
+import {inject, service} from '@loopback/core';
+import {post, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {WORKSPACE_PERMISSION, WorkspacePermission} from '../../constants';
+import {
+  WorkspaceAuthorizationService,
+  WorkspacePermissionDecision,
+} from '../../services';
+
+const KNOWN_PERMISSIONS = new Set<string>(Object.values(WORKSPACE_PERMISSION));
+
+type PermissionCheckRequest = {
+  workspaceId: number;
+  permission: WorkspacePermission;
+};
+
+@authenticate('jwt-header')
+export class AuthorizationController {
+  constructor(
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @post('/authorization/check')
+  async check(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['workspaceId', 'permission'],
+            properties: {
+              workspaceId: {type: 'number'},
+              permission: {
+                type: 'string',
+                enum: Object.values(WORKSPACE_PERMISSION),
+              },
+            },
+          },
+        },
+      },
+    })
+    body: PermissionCheckRequest,
+  ): Promise<WorkspacePermissionDecision> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    if (!KNOWN_PERMISSIONS.has(body.permission)) {
+      return {
+        allowed: false,
+        permission: body.permission,
+        workspaceId: body.workspaceId,
+        role: null,
+      };
+    }
+
+    return this.workspaceAuthorizationService.checkPermission(
+      body.workspaceId,
+      userId,
+      body.permission,
+    );
+  }
+}

--- a/api/src/controllers/system/expertise.controller.ts
+++ b/api/src/controllers/system/expertise.controller.ts
@@ -1,19 +1,195 @@
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept, service} from '@loopback/core';
+import {Count, DataObject, Filter, Where} from '@loopback/repository';
 import {repository} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {Expertise, ExpertiseRelations} from '../../models';
 import {ExpertiseRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const ExpertiseBaseCrudController = createBaseCrudController<
-  Expertise,
-  typeof Expertise.prototype.id,
-  ExpertiseRelations
->('expertises');
-
-export class ExpertiseController extends ExpertiseBaseCrudController {
+@authenticate('jwt-header')
+export class ExpertiseController {
   constructor(
     @repository(ExpertiseRepository)
     private expertiseRepository: ExpertiseRepository,
-  ) {
-    super(expertiseRepository);
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/expertises')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<Expertise>,
+  ): Promise<Expertise[]> {
+    const scopedFilter = await this.scopeExpertiseFilter(userProfile, filter);
+
+    return this.expertiseRepository.find(scopedFilter);
+  }
+
+  @get('/expertises/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<Expertise>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeExpertiseFilter(userProfile, {where});
+
+    return this.expertiseRepository.count(scopedFilter.where);
+  }
+
+  @get('/expertises/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<Expertise> {
+    const expertise = await this.expertiseRepository.findById(id);
+    await this.assertCanViewExpertise(userProfile, expertise);
+
+    return expertise;
+  }
+
+  @get('/Expertises/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof ExpertiseRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<ExpertiseRelations[K]> {
+    const expertise = await this.expertiseRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewExpertise(userProfile, expertise);
+
+    return (expertise as Expertise & ExpertiseRelations)[relationName];
+  }
+
+  @post('/expertises')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Expertise>,
+  ): Promise<Expertise> {
+    await this.assertCanManageExpertise(userProfile, data.workspaceId);
+
+    return this.expertiseRepository.create(data);
+  }
+
+  @patch('/expertises/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Expertise>,
+  ): Promise<void> {
+    const expertise = await this.expertiseRepository.findById(id);
+    await this.assertCanManageExpertise(userProfile, expertise.workspaceId);
+
+    return this.expertiseRepository.updateById(id, data);
+  }
+
+  @put('/expertises/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Expertise>,
+  ): Promise<void> {
+    const expertise = await this.expertiseRepository.findById(id);
+    await this.assertCanManageExpertise(userProfile, expertise.workspaceId);
+
+    return this.expertiseRepository.replaceById(id, data);
+  }
+
+  @del('/expertises/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const expertise = await this.expertiseRepository.findById(id);
+    await this.assertCanManageExpertise(userProfile, expertise.workspaceId);
+
+    return this.expertiseRepository.deleteById(id);
+  }
+
+  private async scopeExpertiseFilter(
+    userProfile: UserProfile,
+    filter: Filter<Expertise> | undefined,
+  ): Promise<Filter<Expertise>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const workspaceWhere: Where<Expertise> = {workspaceId: {inq: workspaceIds}};
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, workspaceWhere]}
+        : workspaceWhere,
+    };
+  }
+
+  private async assertCanViewExpertise(
+    userProfile: UserProfile,
+    expertise: Expertise,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      expertise.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageExpertise(
+    userProfile: UserProfile,
+    workspaceId: number | undefined,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      Number(workspaceId),
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/file.controller.ts
+++ b/api/src/controllers/system/file.controller.ts
@@ -1,8 +1,6 @@
 import {authenticate} from '@loopback/authentication';
-import {repository} from '@loopback/repository';
-import {File, FileRelations} from '../../models';
-import {FileRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {inject, intercept} from '@loopback/core';
+import {Count, Filter, Where, repository} from '@loopback/repository';
 import {
   get,
   param,
@@ -11,45 +9,154 @@ import {
   Response,
   RestBindings,
 } from '@loopback/rest';
-import {inject} from '@loopback/core';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {File, FileRelations} from '../../models';
+import {FileRepository} from '../../repositories';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const FileBaseCrudController = createBaseCrudController<
-  File,
-  typeof File.prototype.id,
-  FileRelations
->('/files');
-
-export class FileController extends FileBaseCrudController {
+export class FileController {
   constructor(
-    @repository(FileRepository) private fileRepository: FileRepository,
-  ) {
-    super(fileRepository);
+    @repository(FileRepository)
+    private fileRepository: FileRepository,
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/files')
+  @authenticate('jwt-header')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<File>,
+  ): Promise<File[]> {
+    const scopedFilter = await this.scopeFileFilter(userProfile, filter);
+
+    return this.fileRepository.find(scopedFilter);
+  }
+
+  @get('/files/count')
+  @authenticate('jwt-header')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<File>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeFileFilter(userProfile, {where});
+
+    return this.fileRepository.count(scopedFilter.where);
+  }
+
+  @get('/files/{id}')
+  @authenticate('jwt-header')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<File> {
+    const file = await this.fileRepository.findById(id);
+    await this.assertCanAccessFile(userProfile, file);
+
+    return file;
+  }
+
+  @get('/Files/{id}/{relationName}')
+  @authenticate('jwt-header')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof FileRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<FileRelations[K]> {
+    const file = await this.fileRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanAccessFile(userProfile, file);
+
+    return (file as File & FileRelations)[relationName];
   }
 
   @post('/files/upload')
   @authenticate('jwt-query')
   async upload(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @inject(RestBindings.Http.REQUEST) request: Request,
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ) {
+    const workspaceId = Number(request.query?.workspaceId);
+
+    if (Number.isFinite(workspaceId)) {
+      const userId =
+        this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+      await this.workspaceAuthorizationService.assertWorkspaceMember(
+        workspaceId,
+        userId,
+      );
+    }
+
     return this.fileRepository.upload(request, response);
   }
 
   @get('/files/{id}/download')
   @authenticate('jwt-query')
   async download(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @param.path.number('id') id: number,
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ) {
+    const file = await this.fileRepository.findById(id);
+    await this.assertCanAccessFile(userProfile, file);
+
     return this.fileRepository.download(id, response);
   }
 
   @get('/files/{id}/preview')
   @authenticate('jwt-query')
   async preview(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @param.path.number('id') id: number,
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ) {
+    const file = await this.fileRepository.findById(id);
+    await this.assertCanAccessFile(userProfile, file);
+
     return this.fileRepository.preview(id, response);
+  }
+
+  private async scopeFileFilter(
+    userProfile: UserProfile,
+    filter: Filter<File> | undefined,
+  ): Promise<Filter<File>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const accessWhere: Where<File> = {workspaceId: {inq: workspaceIds}};
+
+    return {
+      ...filter,
+      where: filter?.where ? {and: [filter.where, accessWhere]} : accessWhere,
+    };
+  }
+
+  private async assertCanAccessFile(
+    userProfile: UserProfile,
+    file: File,
+  ): Promise<void> {
+    if (!file.workspaceId) {
+      return;
+    }
+
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      file.workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/invitation.controller.ts
+++ b/api/src/controllers/system/invitation.controller.ts
@@ -1,25 +1,207 @@
-import {repository} from '@loopback/repository';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {WorkspaceAuthorizationService} from '../../services';
 import {Invitation, InvitationRelations} from '../../models';
 import {InvitationRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
-import {post, requestBody} from '@loopback/rest';
 
-const InvitationBaseCrudController = createBaseCrudController<
-  Invitation,
-  typeof Invitation.prototype.id,
-  InvitationRelations
->('invitations');
-
-export class InvitationController extends InvitationBaseCrudController {
+@authenticate('jwt-header')
+export class InvitationController {
   constructor(
     @repository(InvitationRepository)
     private invitationRepository: InvitationRepository,
-  ) {
-    super(invitationRepository);
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/invitations')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<Invitation>,
+  ): Promise<Invitation[]> {
+    const scopedFilter = await this.scopeInvitationFilter(userProfile, filter);
+
+    return this.invitationRepository.find(scopedFilter);
+  }
+
+  @get('/invitations/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<Invitation>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeInvitationFilter(userProfile, {where});
+
+    return this.invitationRepository.count(scopedFilter.where);
+  }
+
+  @get('/invitations/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<Invitation> {
+    const invitation = await this.invitationRepository.findById(id);
+    await this.assertCanViewInvitation(userProfile, invitation);
+
+    return invitation;
+  }
+
+  @get('/Invitations/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof InvitationRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<InvitationRelations[K]> {
+    const invitation = await this.invitationRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewInvitation(userProfile, invitation);
+
+    return (invitation as Invitation & InvitationRelations)[relationName];
+  }
+
+  @post('/invitations')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Invitation>,
+  ): Promise<Invitation> {
+    await this.assertCanManageInvitation(userProfile, data.workspaceId);
+
+    return this.invitationRepository.create(data);
+  }
+
+  @patch('/invitations/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Invitation>,
+  ): Promise<void> {
+    const invitation = await this.invitationRepository.findById(id);
+    await this.assertCanManageInvitation(userProfile, invitation.workspaceId);
+
+    return this.invitationRepository.updateById(id, data);
+  }
+
+  @put('/invitations/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Invitation>,
+  ): Promise<void> {
+    const invitation = await this.invitationRepository.findById(id);
+    await this.assertCanManageInvitation(userProfile, invitation.workspaceId);
+
+    return this.invitationRepository.replaceById(id, data);
+  }
+
+  @del('/invitations/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const invitation = await this.invitationRepository.findById(id);
+    await this.assertCanManageInvitation(userProfile, invitation.workspaceId);
+
+    return this.invitationRepository.deleteById(id);
   }
 
   @post('/invitations/accept')
   public async accept(@requestBody() body: {invitationId: number}) {
     return await this.invitationRepository.accept(body.invitationId);
+  }
+
+  private async scopeInvitationFilter(
+    userProfile: UserProfile,
+    filter: Filter<Invitation> | undefined,
+  ): Promise<Filter<Invitation>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const workspaceWhere: Where<Invitation> = {
+      workspaceId: {inq: workspaceIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, workspaceWhere]}
+        : workspaceWhere,
+    };
+  }
+
+  private async assertCanViewInvitation(
+    userProfile: UserProfile,
+    invitation: Invitation,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      invitation.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageInvitation(
+    userProfile: UserProfile,
+    workspaceId: number | undefined,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      Number(workspaceId),
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/news-feed-entry-expertise-assoc.controller.ts
+++ b/api/src/controllers/system/news-feed-entry-expertise-assoc.controller.ts
@@ -1,22 +1,243 @@
-import {repository} from '@loopback/repository';
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {
   NewsFeedEntryExpertiseAssoc,
   NewsFeedEntryExpertiseAssocRelations,
 } from '../../models';
-import {NewsFeedEntryExpertiseAssocRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {
+  ExpertiseRepository,
+  NewsFeedEntryExpertiseAssocRepository,
+  NewsFeedEntryRepository,
+} from '../../repositories';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const NewsFeedEntryExpertiseAssocBaseCrudController = createBaseCrudController<
-  NewsFeedEntryExpertiseAssoc,
-  typeof NewsFeedEntryExpertiseAssoc.prototype.id,
-  NewsFeedEntryExpertiseAssocRelations
->('newsFeedEntryExpertiseAssocs');
-
-export class NewsFeedEntryExpertiseAssocController extends NewsFeedEntryExpertiseAssocBaseCrudController {
+@authenticate('jwt-header')
+export class NewsFeedEntryExpertiseAssocController {
   constructor(
     @repository(NewsFeedEntryExpertiseAssocRepository)
     private newsFeedEntryExpertiseAssocRepository: NewsFeedEntryExpertiseAssocRepository,
-  ) {
-    super(newsFeedEntryExpertiseAssocRepository);
+    @repository(NewsFeedEntryRepository)
+    private newsFeedEntryRepository: NewsFeedEntryRepository,
+    @repository(ExpertiseRepository)
+    private expertiseRepository: ExpertiseRepository,
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/newsFeedEntryExpertiseAssocs')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<NewsFeedEntryExpertiseAssoc>,
+  ): Promise<NewsFeedEntryExpertiseAssoc[]> {
+    const scopedFilter = await this.scopeAssocFilter(userProfile, filter);
+
+    return this.newsFeedEntryExpertiseAssocRepository.find(scopedFilter);
+  }
+
+  @get('/newsFeedEntryExpertiseAssocs/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<NewsFeedEntryExpertiseAssoc>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeAssocFilter(userProfile, {where});
+
+    return this.newsFeedEntryExpertiseAssocRepository.count(scopedFilter.where);
+  }
+
+  @get('/newsFeedEntryExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<NewsFeedEntryExpertiseAssoc> {
+    const assoc = await this.newsFeedEntryExpertiseAssocRepository.findById(id);
+    await this.assertCanViewAssoc(userProfile, assoc);
+
+    return assoc;
+  }
+
+  @get('/NewsFeedEntryExpertiseAssocs/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<
+    K extends keyof NewsFeedEntryExpertiseAssocRelations,
+  >(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<NewsFeedEntryExpertiseAssocRelations[K]> {
+    const assoc = await this.newsFeedEntryExpertiseAssocRepository.findById(
+      id,
+      {
+        include: [relationName as string],
+      },
+    );
+    await this.assertCanViewAssoc(userProfile, assoc);
+
+    return (
+      assoc as NewsFeedEntryExpertiseAssoc &
+        NewsFeedEntryExpertiseAssocRelations
+    )[relationName];
+  }
+
+  @post('/newsFeedEntryExpertiseAssocs')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntryExpertiseAssoc>,
+  ): Promise<NewsFeedEntryExpertiseAssoc> {
+    await this.assertCanManageAssoc(userProfile, {
+      newsFeedEntryId: Number(data.newsFeedEntryId),
+      expertiseId: Number(data.expertiseId),
+    });
+
+    return this.newsFeedEntryExpertiseAssocRepository.create(data);
+  }
+
+  @patch('/newsFeedEntryExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntryExpertiseAssoc>,
+  ): Promise<void> {
+    const assoc = await this.newsFeedEntryExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, {...assoc, ...data});
+
+    return this.newsFeedEntryExpertiseAssocRepository.updateById(id, data);
+  }
+
+  @put('/newsFeedEntryExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntryExpertiseAssoc>,
+  ): Promise<void> {
+    const assoc = await this.newsFeedEntryExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, {...assoc, ...data});
+
+    return this.newsFeedEntryExpertiseAssocRepository.replaceById(id, data);
+  }
+
+  @del('/newsFeedEntryExpertiseAssocs/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const assoc = await this.newsFeedEntryExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, assoc);
+
+    return this.newsFeedEntryExpertiseAssocRepository.deleteById(id);
+  }
+
+  private async scopeAssocFilter(
+    userProfile: UserProfile,
+    filter: Filter<NewsFeedEntryExpertiseAssoc> | undefined,
+  ): Promise<Filter<NewsFeedEntryExpertiseAssoc>> {
+    const entryIds = await this.accessibleNewsFeedEntryIds(userProfile);
+    const accessWhere: Where<NewsFeedEntryExpertiseAssoc> = {
+      newsFeedEntryId: {inq: entryIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where ? {and: [filter.where, accessWhere]} : accessWhere,
+    };
+  }
+
+  private async accessibleNewsFeedEntryIds(
+    userProfile: UserProfile,
+  ): Promise<number[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const entries = await this.newsFeedEntryRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+
+    return entries.map(entry => entry.id);
+  }
+
+  private async assertCanViewAssoc(
+    userProfile: UserProfile,
+    assoc: NewsFeedEntryExpertiseAssoc,
+  ): Promise<void> {
+    const entry = await this.newsFeedEntryRepository.findById(
+      assoc.newsFeedEntryId,
+    );
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      entry.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageAssoc(
+    userProfile: UserProfile,
+    assoc: Pick<NewsFeedEntryExpertiseAssoc, 'newsFeedEntryId' | 'expertiseId'>,
+  ): Promise<void> {
+    const entry = await this.newsFeedEntryRepository.findById(
+      assoc.newsFeedEntryId,
+    );
+    const expertise = await this.expertiseRepository.findById(
+      assoc.expertiseId,
+    );
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      entry.workspaceId,
+      userId,
+    );
+
+    if (expertise.workspaceId !== entry.workspaceId) {
+      await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+        expertise.workspaceId,
+        userId,
+      );
+    }
   }
 }

--- a/api/src/controllers/system/news-feed-entry.controller.ts
+++ b/api/src/controllers/system/news-feed-entry.controller.ts
@@ -1,29 +1,53 @@
 import {authenticate} from '@loopback/authentication';
-import {intercept, service} from '@loopback/core';
-import {inject} from '@loopback/core';
-import {param, get} from '@loopback/rest';
-import {repository} from '@loopback/repository';
+import {inject, intercept, service} from '@loopback/core';
+import {
+  Count,
+  DataObject,
+  Filter,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {NewsFeedEntry, NewsFeedEntryRelations} from '../../models';
 import {NewsFeedEntryRepository} from '../../repositories';
 import {WorkspaceAuthorizationService} from '../../services';
-import {createBaseCrudController} from '../base-crud.controller';
-
-const NewsFeedEntryBaseCrudController = createBaseCrudController<
-  NewsFeedEntry,
-  typeof NewsFeedEntry.prototype.id,
-  NewsFeedEntryRelations
->('newsFeedEntries');
 
 @authenticate('jwt-header')
-export class NewsFeedEntryController extends NewsFeedEntryBaseCrudController {
+export class NewsFeedEntryController {
   constructor(
     @repository(NewsFeedEntryRepository)
     public repository: NewsFeedEntryRepository,
     @service(WorkspaceAuthorizationService)
     private workspaceAuthorizationService: WorkspaceAuthorizationService,
-  ) {
-    super(repository);
+  ) {}
+
+  @get('/newsFeedEntries')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<NewsFeedEntry>,
+  ): Promise<NewsFeedEntry[]> {
+    const scopedFilter = await this.scopeNewsFeedEntryFilter(
+      userProfile,
+      filter,
+    );
+
+    return this.repository.find(scopedFilter);
+  }
+
+  @get('/newsFeedEntries/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<NewsFeedEntry>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeNewsFeedEntryFilter(userProfile, {
+      where,
+    });
+
+    return this.repository.count(scopedFilter.where);
   }
 
   @get('/newsFeedEntries/feed')
@@ -41,5 +65,170 @@ export class NewsFeedEntryController extends NewsFeedEntryBaseCrudController {
     );
 
     return this.repository.findPersonalizedFeed(workspaceId, userId);
+  }
+
+  @get('/newsFeedEntries/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<NewsFeedEntry> {
+    const entry = await this.repository.findById(id);
+    await this.assertCanViewEntry(userProfile, entry);
+
+    return entry;
+  }
+
+  @get('/NewsFeedEntries/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof NewsFeedEntryRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<NewsFeedEntryRelations[K]> {
+    const entry = await this.repository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewEntry(userProfile, entry);
+
+    return (entry as NewsFeedEntry & NewsFeedEntryRelations)[relationName];
+  }
+
+  @post('/newsFeedEntries')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntry>,
+  ): Promise<NewsFeedEntry> {
+    await this.assertCanManageWorkspace(userProfile, Number(data.workspaceId));
+
+    return this.repository.create(data);
+  }
+
+  @patch('/newsFeedEntries/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntry>,
+  ): Promise<void> {
+    const entry = await this.repository.findById(id);
+    await this.assertCanManageEntryUpdate(userProfile, entry, data);
+
+    return this.repository.updateById(id, data);
+  }
+
+  @put('/newsFeedEntries/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {'x-ts-type': Object},
+        },
+      },
+    })
+    data: DataObject<NewsFeedEntry>,
+  ): Promise<void> {
+    const entry = await this.repository.findById(id);
+    await this.assertCanManageEntryUpdate(userProfile, entry, data);
+
+    return this.repository.replaceById(id, data);
+  }
+
+  @del('/newsFeedEntries/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const entry = await this.repository.findById(id);
+    await this.assertCanManageWorkspace(userProfile, entry.workspaceId);
+
+    return this.repository.deleteById(id);
+  }
+
+  private async scopeNewsFeedEntryFilter(
+    userProfile: UserProfile,
+    filter: Filter<NewsFeedEntry> | undefined,
+  ): Promise<Filter<NewsFeedEntry>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const accessWhere: Where<NewsFeedEntry> = {
+      workspaceId: {inq: workspaceIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where ? {and: [filter.where, accessWhere]} : accessWhere,
+    };
+  }
+
+  private async assertCanViewEntry(
+    userProfile: UserProfile,
+    entry: NewsFeedEntry,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      entry.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageEntryUpdate(
+    userProfile: UserProfile,
+    entry: NewsFeedEntry,
+    data: DataObject<NewsFeedEntry>,
+  ): Promise<void> {
+    await this.assertCanManageWorkspace(userProfile, entry.workspaceId);
+
+    if (
+      data.workspaceId !== undefined &&
+      Number(data.workspaceId) !== entry.workspaceId
+    ) {
+      await this.assertCanManageWorkspace(
+        userProfile,
+        Number(data.workspaceId),
+      );
+    }
+  }
+
+  private async assertCanManageWorkspace(
+    userProfile: UserProfile,
+    workspaceId: number,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/news-feed-entry.controller.ts
+++ b/api/src/controllers/system/news-feed-entry.controller.ts
@@ -1,8 +1,12 @@
-import {intercept} from '@loopback/core';
+import {authenticate} from '@loopback/authentication';
+import {intercept, service} from '@loopback/core';
+import {inject} from '@loopback/core';
 import {param, get} from '@loopback/rest';
 import {repository} from '@loopback/repository';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {NewsFeedEntry, NewsFeedEntryRelations} from '../../models';
 import {NewsFeedEntryRepository} from '../../repositories';
+import {WorkspaceAuthorizationService} from '../../services';
 import {createBaseCrudController} from '../base-crud.controller';
 
 const NewsFeedEntryBaseCrudController = createBaseCrudController<
@@ -11,10 +15,13 @@ const NewsFeedEntryBaseCrudController = createBaseCrudController<
   NewsFeedEntryRelations
 >('newsFeedEntries');
 
+@authenticate('jwt-header')
 export class NewsFeedEntryController extends NewsFeedEntryBaseCrudController {
   constructor(
     @repository(NewsFeedEntryRepository)
     public repository: NewsFeedEntryRepository,
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
   ) {
     super(repository);
   }
@@ -22,9 +29,17 @@ export class NewsFeedEntryController extends NewsFeedEntryBaseCrudController {
   @get('/newsFeedEntries/feed')
   @intercept('interceptors.json-api-serializer')
   public async feed(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
     @param.query.number('workspaceId') workspaceId: number,
-    @param.query.number('userId') userId: number,
   ): Promise<NewsFeedEntry[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      workspaceId,
+      userId,
+    );
+
     return this.repository.findPersonalizedFeed(workspaceId, userId);
   }
 }

--- a/api/src/controllers/system/user-expertise-assoc.controller.ts
+++ b/api/src/controllers/system/user-expertise-assoc.controller.ts
@@ -1,19 +1,212 @@
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept} from '@loopback/core';
+import {Count, DataObject, Filter, Where} from '@loopback/repository';
 import {repository} from '@loopback/repository';
 import {UserExpertiseAssoc, UserExpertiseAssocRelations} from '../../models';
-import {UserExpertiseAssocRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {
+  ExpertiseRepository,
+  UserExpertiseAssocRepository,
+} from '../../repositories';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const UserExpertiseAssocBaseCrudController = createBaseCrudController<
-  UserExpertiseAssoc,
-  typeof UserExpertiseAssoc.prototype.id,
-  UserExpertiseAssocRelations
->('userExpertiseAssocs');
-
-export class UserExpertiseAssocController extends UserExpertiseAssocBaseCrudController {
+@authenticate('jwt-header')
+export class UserExpertiseAssocController {
   constructor(
     @repository(UserExpertiseAssocRepository)
     private userExpertiseAssocRepository: UserExpertiseAssocRepository,
-  ) {
-    super(userExpertiseAssocRepository);
+    @repository(ExpertiseRepository)
+    private expertiseRepository: ExpertiseRepository,
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/userExpertiseAssocs')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<UserExpertiseAssoc>,
+  ): Promise<UserExpertiseAssoc[]> {
+    const scopedFilter = await this.scopeAssocFilter(userProfile, filter);
+
+    return this.userExpertiseAssocRepository.find(scopedFilter);
+  }
+
+  @get('/userExpertiseAssocs/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<UserExpertiseAssoc>,
+  ): Promise<Count> {
+    const scopedFilter = await this.scopeAssocFilter(userProfile, {where});
+
+    return this.userExpertiseAssocRepository.count(scopedFilter.where);
+  }
+
+  @get('/userExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<UserExpertiseAssoc> {
+    const assoc = await this.userExpertiseAssocRepository.findById(id);
+    await this.assertCanViewAssoc(userProfile, assoc);
+
+    return assoc;
+  }
+
+  @get('/UserExpertiseAssocs/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof UserExpertiseAssocRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<UserExpertiseAssocRelations[K]> {
+    const assoc = await this.userExpertiseAssocRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewAssoc(userProfile, assoc);
+
+    return (assoc as UserExpertiseAssoc & UserExpertiseAssocRelations)[
+      relationName
+    ];
+  }
+
+  @post('/userExpertiseAssocs')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<UserExpertiseAssoc>,
+  ): Promise<UserExpertiseAssoc> {
+    await this.assertCanManageAssoc(userProfile, Number(data.expertiseId));
+
+    return this.userExpertiseAssocRepository.create(data);
+  }
+
+  @patch('/userExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<UserExpertiseAssoc>,
+  ): Promise<void> {
+    const assoc = await this.userExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
+
+    return this.userExpertiseAssocRepository.updateById(id, data);
+  }
+
+  @put('/userExpertiseAssocs/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<UserExpertiseAssoc>,
+  ): Promise<void> {
+    const assoc = await this.userExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
+
+    return this.userExpertiseAssocRepository.replaceById(id, data);
+  }
+
+  @del('/userExpertiseAssocs/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const assoc = await this.userExpertiseAssocRepository.findById(id);
+    await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
+
+    return this.userExpertiseAssocRepository.deleteById(id);
+  }
+
+  private async scopeAssocFilter(
+    userProfile: UserProfile,
+    filter: Filter<UserExpertiseAssoc> | undefined,
+  ): Promise<Filter<UserExpertiseAssoc>> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const workspaceIds =
+      await this.workspaceAuthorizationService.accessibleWorkspaceIds(userId);
+    const expertises = await this.expertiseRepository.find({
+      where: {workspaceId: {inq: workspaceIds}},
+    });
+    const expertiseIds = expertises.map(expertise => expertise.id);
+    const expertiseWhere: Where<UserExpertiseAssoc> = {
+      expertiseId: {inq: expertiseIds},
+    };
+
+    return {
+      ...filter,
+      where: filter?.where
+        ? {and: [filter.where, expertiseWhere]}
+        : expertiseWhere,
+    };
+  }
+
+  private async assertCanViewAssoc(
+    userProfile: UserProfile,
+    assoc: UserExpertiseAssoc,
+  ): Promise<void> {
+    const expertise = await this.expertiseRepository.findById(
+      assoc.expertiseId,
+    );
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      expertise.workspaceId,
+      userId,
+    );
+  }
+
+  private async assertCanManageAssoc(
+    userProfile: UserProfile,
+    expertiseId: number,
+  ): Promise<void> {
+    const expertise = await this.expertiseRepository.findById(expertiseId);
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      expertise.workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/workspace-member.controller.ts
+++ b/api/src/controllers/system/workspace-member.controller.ts
@@ -1,19 +1,202 @@
+import {authenticate} from '@loopback/authentication';
+import {inject, intercept} from '@loopback/core';
+import {Count, DataObject, Filter, Where} from '@loopback/repository';
 import {repository} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import {WorkspaceMember, WorkspaceMemberRelations} from '../../models';
 import {WorkspaceMemberRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {WorkspaceAuthorizationService} from '../../services';
 
-const WorkspaceMemberBaseCrudController = createBaseCrudController<
-  WorkspaceMember,
-  typeof WorkspaceMember.prototype.id,
-  WorkspaceMemberRelations
->('workspaceMembers');
-
-export class WorkspaceMemberController extends WorkspaceMemberBaseCrudController {
+@authenticate('jwt-header')
+export class WorkspaceMemberController {
   constructor(
     @repository(WorkspaceMemberRepository)
     private workspaceMemberRepository: WorkspaceMemberRepository,
-  ) {
-    super(workspaceMemberRepository);
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/workspaceMembers')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<WorkspaceMember>,
+  ): Promise<WorkspaceMember[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const scopedWhere =
+      await this.workspaceAuthorizationService.mergeWorkspaceMemberAccessWhere(
+        filter?.where,
+        userId,
+      );
+
+    return this.workspaceMemberRepository.find({
+      ...filter,
+      where: scopedWhere,
+    });
+  }
+
+  @get('/workspaceMembers/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<WorkspaceMember>,
+  ): Promise<Count> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const scopedWhere =
+      await this.workspaceAuthorizationService.mergeWorkspaceMemberAccessWhere(
+        where,
+        userId,
+      );
+
+    return this.workspaceMemberRepository.count(scopedWhere);
+  }
+
+  @get('/workspaceMembers/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<WorkspaceMember> {
+    const member = await this.workspaceMemberRepository.findById(id);
+    await this.assertCanViewMember(userProfile, member);
+
+    return member;
+  }
+
+  @get('/WorkspaceMembers/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof WorkspaceMemberRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<WorkspaceMemberRelations[K]> {
+    const member = await this.workspaceMemberRepository.findById(id, {
+      include: [relationName as string],
+    });
+    await this.assertCanViewMember(userProfile, member);
+
+    return (member as WorkspaceMember & WorkspaceMemberRelations)[relationName];
+  }
+
+  @post('/workspaceMembers')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<WorkspaceMember>,
+  ): Promise<WorkspaceMember> {
+    await this.assertCanManageMember(userProfile, data.workspaceId);
+
+    return this.workspaceMemberRepository.create(data);
+  }
+
+  @patch('/workspaceMembers/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<WorkspaceMember>,
+  ): Promise<void> {
+    const member = await this.workspaceMemberRepository.findById(id);
+    await this.assertCanManageMember(userProfile, member.workspaceId);
+
+    return this.workspaceMemberRepository.updateById(id, data);
+  }
+
+  @put('/workspaceMembers/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<WorkspaceMember>,
+  ): Promise<void> {
+    const member = await this.workspaceMemberRepository.findById(id);
+    await this.assertCanManageMember(userProfile, member.workspaceId);
+
+    return this.workspaceMemberRepository.replaceById(id, data);
+  }
+
+  @del('/workspaceMembers/{id}')
+  public async deleteById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+  ): Promise<void> {
+    const member = await this.workspaceMemberRepository.findById(id);
+    await this.assertCanManageMember(userProfile, member.workspaceId);
+
+    return this.workspaceMemberRepository.deleteById(id);
+  }
+
+  @patch('/workspaceMembers')
+  public async updateAll(): Promise<Count> {
+    return {count: 0};
+  }
+
+  @del('/workspaceMembers')
+  public async deleteAll(): Promise<Count> {
+    return {count: 0};
+  }
+
+  private async assertCanViewMember(
+    userProfile: UserProfile,
+    member: WorkspaceMember,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      Number(member.workspaceId),
+      userId,
+    );
+  }
+
+  private async assertCanManageMember(
+    userProfile: UserProfile,
+    workspaceId: number | undefined,
+  ): Promise<void> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceAdminOrOwner(
+      Number(workspaceId),
+      userId,
+    );
   }
 }

--- a/api/src/controllers/system/workspace.controller.ts
+++ b/api/src/controllers/system/workspace.controller.ts
@@ -1,19 +1,219 @@
+import {authenticate} from '@loopback/authentication';
+import {authorize} from '@loopback/authorization';
+import {inject, intercept} from '@loopback/core';
+import {Count, DataObject, Filter, Where} from '@loopback/repository';
 import {repository} from '@loopback/repository';
+import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {WORKSPACE_PERMISSION} from '../../constants';
 import {Workspace, WorkspaceRelations} from '../../models';
 import {WorkspaceRepository} from '../../repositories';
-import {createBaseCrudController} from '../base-crud.controller';
+import {WorkspaceAuthorizationService} from '../../services';
+import {WORKSPACE_AUTHORIZER} from '../../authorization/workspace-authorizer.provider';
 
-const WorkspaceBaseCrudController = createBaseCrudController<
-  Workspace,
-  typeof Workspace.prototype.id,
-  WorkspaceRelations
->('workspaces');
+const OWNER_ONLY_WORKSPACE_FIELDS = new Set<keyof Workspace>([
+  'githubInstallationId',
+  'issueSync',
+  'issueSyncDone',
+  'prSyncDone',
+  'capacityPlanningSync',
+  'prRiskPredictionSync',
+  'reviewerSuggestionSync',
+  'prReviewReminderCron',
+]);
 
-export class WorkspaceController extends WorkspaceBaseCrudController {
+@authenticate('jwt-header')
+export class WorkspaceController {
   constructor(
     @repository(WorkspaceRepository)
     private workspaceRepository: WorkspaceRepository,
-  ) {
-    super(workspaceRepository);
+    @inject('services.WorkspaceAuthorizationService')
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  @get('/workspaces')
+  @intercept('interceptors.json-api-serializer')
+  public async find(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('filter') filter?: Filter<Workspace>,
+  ): Promise<Workspace[]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const scopedFilter =
+      await this.workspaceAuthorizationService.mergeWorkspaceAccessFilter(
+        filter,
+        userId,
+      );
+
+    return this.workspaceRepository.find(scopedFilter);
+  }
+
+  @get('/workspaces/count')
+  public async count(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.query.object('where') where?: Where<Workspace>,
+  ): Promise<Count> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    const scopedFilter =
+      await this.workspaceAuthorizationService.mergeWorkspaceAccessFilter(
+        {where},
+        userId,
+      );
+
+    return this.workspaceRepository.count(scopedFilter.where);
+  }
+
+  @authorize({
+    resource: WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+    voters: [WORKSPACE_AUTHORIZER],
+  })
+  @get('/workspaces/{id}')
+  @intercept('interceptors.json-api-serializer')
+  public async findById(
+    @param.path.number('id') id: number,
+  ): Promise<Workspace> {
+    return this.workspaceRepository.findById(id);
+  }
+
+  @get('/Workspaces/{id}/{relationName}')
+  @intercept('interceptors.json-api-serializer')
+  public async getRelation<K extends keyof WorkspaceRelations>(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @param.path.string('relationName') relationName: K,
+  ): Promise<WorkspaceRelations[K]> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+    await this.workspaceAuthorizationService.assertWorkspaceMember(id, userId);
+
+    const entity: Workspace & WorkspaceRelations =
+      await this.workspaceRepository.findById(id, {
+        include: [relationName as string],
+      });
+
+    return entity[relationName];
+  }
+
+  @post('/workspaces')
+  @intercept('interceptors.json-api-deserializer')
+  @intercept('interceptors.json-api-serializer')
+  public async create(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Workspace>,
+  ): Promise<Workspace> {
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    return this.workspaceRepository.create({
+      ...data,
+      ownerId: userId,
+    });
+  }
+
+  @authorize({
+    resource: WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+    voters: [WORKSPACE_AUTHORIZER],
+  })
+  @patch('/workspaces/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async updateById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Workspace>,
+  ): Promise<void> {
+    await this.assertOwnerForSensitiveWorkspaceFields(id, userProfile, data);
+
+    return this.workspaceRepository.updateById(id, data);
+  }
+
+  @authorize({
+    resource: WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+    voters: [WORKSPACE_AUTHORIZER],
+  })
+  @put('/workspaces/{id}')
+  @intercept('interceptors.json-api-deserializer')
+  public async replaceById(
+    @inject(SecurityBindings.USER)
+    userProfile: UserProfile,
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/vnd.api+json': {
+          schema: {
+            'x-ts-type': Object,
+          },
+        },
+      },
+    })
+    data: DataObject<Workspace>,
+  ): Promise<void> {
+    await this.assertOwnerForSensitiveWorkspaceFields(id, userProfile, data);
+
+    return this.workspaceRepository.replaceById(id, data);
+  }
+
+  @authorize({
+    resource: WORKSPACE_PERMISSION.WORKSPACE_DELETE,
+    voters: [WORKSPACE_AUTHORIZER],
+  })
+  @del('/workspaces/{id}')
+  public async deleteById(@param.path.number('id') id: number): Promise<void> {
+    return this.workspaceRepository.deleteById(id);
+  }
+
+  @patch('/workspaces')
+  public async updateAll(): Promise<Count> {
+    return {count: 0};
+  }
+
+  @del('/workspaces')
+  public async deleteAll(): Promise<Count> {
+    return {count: 0};
+  }
+
+  private async assertOwnerForSensitiveWorkspaceFields(
+    workspaceId: number,
+    userProfile: UserProfile,
+    data: DataObject<Workspace>,
+  ): Promise<void> {
+    if (
+      !Object.keys(data).some(key =>
+        OWNER_ONLY_WORKSPACE_FIELDS.has(key as keyof Workspace),
+      )
+    ) {
+      return;
+    }
+
+    const userId =
+      this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
+
+    await this.workspaceAuthorizationService.assertWorkspaceOwner(
+      workspaceId,
+      userId,
+    );
   }
 }

--- a/api/src/interceptors/json-api-deserializer.interceptor.ts
+++ b/api/src/interceptors/json-api-deserializer.interceptor.ts
@@ -129,10 +129,32 @@ export class JsonApiDeserializerInterceptor implements Provider<Interceptor> {
   private getEntityClassFromContext(
     invocationCtx: InvocationContext,
   ): typeof Entity | undefined {
-    const target = invocationCtx.target as {
-      repository?: {entityClass?: typeof Entity};
-    };
-    return target.repository?.entityClass;
+    const target = invocationCtx.target as Record<string, unknown>;
+    const repository = this.getRepositoryFromTarget(target);
+
+    return repository?.entityClass;
+  }
+
+  private getRepositoryFromTarget(
+    target: Record<string, unknown>,
+  ): {entityClass?: typeof Entity} | undefined {
+    const directRepository = target.repository;
+
+    if (this.isRepository(directRepository)) {
+      return directRepository;
+    }
+
+    for (const value of Object.values(target)) {
+      if (this.isRepository(value)) {
+        return value;
+      }
+    }
+
+    return undefined;
+  }
+
+  private isRepository(value: unknown): value is {entityClass?: typeof Entity} {
+    return this.isRecord(value) && 'entityClass' in value;
   }
 
   private isRecord(value: unknown): value is JsonRecord {

--- a/api/src/interceptors/json-api-serializer.interceptor.ts
+++ b/api/src/interceptors/json-api-serializer.interceptor.ts
@@ -195,10 +195,32 @@ export class JsonApiSerializerInterceptor implements Provider<Interceptor> {
   private getEntityClassFromContext(
     invocationCtx: InvocationContext,
   ): typeof Entity | undefined {
-    const target = invocationCtx.target as {
-      repository?: {entityClass?: typeof Entity};
-    };
-    return target.repository?.entityClass;
+    const target = invocationCtx.target as Record<string, unknown>;
+    const repository = this.getRepositoryFromTarget(target);
+
+    return repository?.entityClass;
+  }
+
+  private getRepositoryFromTarget(
+    target: Record<string, unknown>,
+  ): {entityClass?: typeof Entity} | undefined {
+    const directRepository = target.repository;
+
+    if (this.isRepository(directRepository)) {
+      return directRepository;
+    }
+
+    for (const value of Object.values(target)) {
+      if (this.isRepository(value)) {
+        return value;
+      }
+    }
+
+    return undefined;
+  }
+
+  private isRepository(value: unknown): value is {entityClass?: typeof Entity} {
+    return this.isRecord(value) && 'entityClass' in value;
   }
 
   private asRecordArray(value: unknown): JsonRecord[] | undefined {

--- a/api/src/models/github/github-installation-state.model.ts
+++ b/api/src/models/github/github-installation-state.model.ts
@@ -1,0 +1,59 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model({
+  settings: {
+    forceId: false,
+    postgresql: {schema: 'github', table: 'installation_state'},
+  },
+})
+export class GithubInstallationState extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    postgresql: {columnName: 'nonce'},
+  })
+  nonce: string;
+
+  @property({
+    type: 'number',
+    required: true,
+    postgresql: {columnName: 'workspace_id'},
+  })
+  workspaceId: number;
+
+  @property({
+    type: 'number',
+    required: true,
+    postgresql: {columnName: 'user_id'},
+  })
+  userId: number;
+
+  @property({
+    type: 'date',
+    required: true,
+    postgresql: {columnName: 'issued_at'},
+  })
+  issuedAt: Date;
+
+  @property({
+    type: 'date',
+    required: true,
+    postgresql: {columnName: 'expires_at'},
+  })
+  expiresAt: Date;
+
+  @property({
+    type: 'date',
+    postgresql: {columnName: 'consumed_at'},
+  })
+  consumedAt?: Date | null;
+
+  constructor(data?: Partial<GithubInstallationState>) {
+    super(data);
+  }
+}
+
+export type GithubInstallationStateRelations = object;
+
+export type GithubInstallationStateWithRelations = GithubInstallationState &
+  GithubInstallationStateRelations;

--- a/api/src/models/github/index.ts
+++ b/api/src/models/github/index.ts
@@ -1,3 +1,4 @@
+export * from './github-installation-state.model';
 export * from './issue.model';
 export * from './label.model';
 export * from './pull-request.model';

--- a/api/src/repositories/github/github-installation-state.repository.ts
+++ b/api/src/repositories/github/github-installation-state.repository.ts
@@ -1,0 +1,19 @@
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {PostgresDbDataSource} from '../../datasources';
+import {
+  GithubInstallationState,
+  GithubInstallationStateRelations,
+} from '../../models';
+
+export class GithubInstallationStateRepository extends DefaultCrudRepository<
+  GithubInstallationState,
+  typeof GithubInstallationState.prototype.nonce,
+  GithubInstallationStateRelations
+> {
+  constructor(
+    @inject('datasources.postgresDB') dataSource: PostgresDbDataSource,
+  ) {
+    super(GithubInstallationState, dataSource);
+  }
+}

--- a/api/src/repositories/github/index.ts
+++ b/api/src/repositories/github/index.ts
@@ -1,3 +1,4 @@
+export * from './github-installation-state.repository';
 export * from './issue.repository';
 export * from './label.repository';
 export * from './pull-request.repository';

--- a/api/src/services/github-integration/github.service.ts
+++ b/api/src/services/github-integration/github.service.ts
@@ -2,13 +2,14 @@
 import {BindingScope, Getter, injectable, service} from '@loopback/core';
 import {repository} from '@loopback/repository';
 import {HttpErrors, Response} from '@loopback/rest';
-import {createHmac, timingSafeEqual} from 'crypto';
+import {createHmac, randomBytes, timingSafeEqual} from 'crypto';
 import {App} from 'octokit';
 import {
   IssuePriorityService,
   type IssuePriorityPrediction,
 } from '../issue-priority.service';
 import {
+  GithubInstallationStateRepository,
   GithubRepositoryRepository,
   WorkspaceRepository,
 } from '../../repositories';
@@ -143,6 +144,8 @@ export class GithubService {
     private workspaceRepositoryGetter: Getter<WorkspaceRepository>,
     @repository.getter('GithubRepositoryRepository')
     private githubRepositoryRepositoryGetter: Getter<GithubRepositoryRepository>,
+    @repository.getter('GithubInstallationStateRepository')
+    private githubInstallationStateRepositoryGetter: Getter<GithubInstallationStateRepository>,
     @service(QueueService)
     private queueService: QueueService,
     @service(IssuePriorityService)
@@ -172,7 +175,7 @@ export class GithubService {
     if (state) {
       installationUrl.searchParams.set(
         'state',
-        this.createInstallationStateToken(state),
+        await this.createInstallationStateToken(state),
       );
     }
 
@@ -200,7 +203,7 @@ export class GithubService {
     }
 
     const callbackUrl = new URL('/workspaces/callback', this.clientUrl);
-    const workspaceId = this.parseWorkspaceId(state);
+    const workspaceId = await this.parseWorkspaceId(state);
 
     if (workspaceId) {
       callbackUrl.searchParams.set('workspaceId', workspaceId.toString());
@@ -311,26 +314,29 @@ export class GithubService {
     };
   }
 
-  private parseWorkspaceId(state?: string): number | undefined {
+  private async parseWorkspaceId(state?: string): Promise<number | undefined> {
     if (!state) {
       return undefined;
     }
 
     const parts = state.trim().split('.');
 
-    if (parts.length !== 3 && parts.length !== 4) {
+    if (parts.length !== 5) {
       console.warn('GitHub App callback received invalid workspace state', {
         state,
       });
       return undefined;
     }
 
-    const hasUserId = parts.length === 4;
-    const [workspaceIdText, maybeUserIdText, maybeIssuedAtText, signature] =
-      hasUserId ? parts : [parts[0], undefined, parts[1], parts[2]];
-    const issuedAtText = maybeIssuedAtText;
+    const [workspaceIdText, userIdText, nonce, issuedAtText, signature] = parts;
 
-    if (!workspaceIdText || !issuedAtText || !signature) {
+    if (
+      !workspaceIdText ||
+      !userIdText ||
+      !nonce ||
+      !issuedAtText ||
+      !signature
+    ) {
       console.warn('GitHub App callback received invalid workspace state', {
         state,
       });
@@ -338,13 +344,14 @@ export class GithubService {
     }
 
     const workspaceId = Number(workspaceIdText);
-    const userId = maybeUserIdText ? Number(maybeUserIdText) : undefined;
+    const userId = Number(userIdText);
     const issuedAt = Number(issuedAtText);
 
     if (
       !workspaceId ||
       Number.isNaN(workspaceId) ||
-      (maybeUserIdText && (!userId || Number.isNaN(userId))) ||
+      !userId ||
+      Number.isNaN(userId) ||
       !issuedAt ||
       Number.isNaN(issuedAt)
     ) {
@@ -362,9 +369,7 @@ export class GithubService {
       return undefined;
     }
 
-    const signedPayload = hasUserId
-      ? `${workspaceId}.${userId}.${issuedAt}`
-      : `${workspaceId}.${issuedAt}`;
+    const signedPayload = `${workspaceId}.${userId}.${nonce}.${issuedAt}`;
     const expectedSignature = createHmac('sha256', this.appStateSecret)
       .update(signedPayload)
       .digest('hex');
@@ -379,17 +384,65 @@ export class GithubService {
       return undefined;
     }
 
+    if (
+      !(await this.consumeInstallationStateNonce(nonce, workspaceId, userId))
+    ) {
+      return undefined;
+    }
+
     return workspaceId;
   }
 
-  private createInstallationStateToken(state: GithubInstallationState): string {
+  private async createInstallationStateToken(
+    state: GithubInstallationState,
+  ): Promise<string> {
     const issuedAt = Date.now();
-    const signedPayload = `${state.workspaceId}.${state.userId}.${issuedAt}`;
+    const nonce = randomBytes(24).toString('hex');
+    const signedPayload = `${state.workspaceId}.${state.userId}.${nonce}.${issuedAt}`;
     const signature = createHmac('sha256', this.appStateSecret)
       .update(signedPayload)
       .digest('hex');
 
+    const repository = await this.githubInstallationStateRepositoryGetter();
+    await repository.create({
+      nonce,
+      workspaceId: state.workspaceId,
+      userId: state.userId,
+      issuedAt: new Date(issuedAt),
+      expiresAt: new Date(issuedAt + INSTALLATION_STATE_TTL_MS),
+      consumedAt: null,
+    });
+
     return `${signedPayload}.${signature}`;
+  }
+
+  private async consumeInstallationStateNonce(
+    nonce: string,
+    workspaceId: number,
+    userId: number,
+  ): Promise<boolean> {
+    const repository = await this.githubInstallationStateRepositoryGetter();
+    const state = await repository.findById(nonce).catch(() => undefined);
+
+    if (
+      !state ||
+      state.workspaceId !== workspaceId ||
+      state.userId !== userId ||
+      state.consumedAt ||
+      state.expiresAt.getTime() <= Date.now()
+    ) {
+      console.warn('GitHub App callback received replayed or expired state', {
+        workspaceId,
+        userId,
+      });
+      return false;
+    }
+
+    await repository.updateById(nonce, {
+      consumedAt: new Date(),
+    });
+
+    return true;
   }
 
   private async saveInstallationRepositories(

--- a/api/src/services/github-integration/github.service.ts
+++ b/api/src/services/github-integration/github.service.ts
@@ -81,6 +81,11 @@ type GithubRepositoryDirectoryEntry = {
   size?: number;
 };
 
+export type GithubInstallationState = {
+  workspaceId: number;
+  userId: number;
+};
+
 type GithubPullRequestOverview = {
   number: number;
   title: string;
@@ -155,17 +160,19 @@ export class GithubService {
       process.env.GITHUB_APP_STATE_SECRET ?? process.env.GITHUB_WEBHOOK_SECRET!;
   }
 
-  public async getInstallationUrl(workspaceId?: string): Promise<string> {
+  public async getInstallationUrl(
+    state?: GithubInstallationState,
+  ): Promise<string> {
     const appInfo = await this.getGithubAppInfo();
     const installationUrl = new URL(
       `/apps/${appInfo.slug}/installations/new`,
       'https://github.com',
     );
 
-    if (workspaceId) {
+    if (state) {
       installationUrl.searchParams.set(
         'state',
-        this.createInstallationStateToken(workspaceId),
+        this.createInstallationStateToken(state),
       );
     }
 
@@ -309,7 +316,19 @@ export class GithubService {
       return undefined;
     }
 
-    const [workspaceIdText, issuedAtText, signature] = state.trim().split('.');
+    const parts = state.trim().split('.');
+
+    if (parts.length !== 3 && parts.length !== 4) {
+      console.warn('GitHub App callback received invalid workspace state', {
+        state,
+      });
+      return undefined;
+    }
+
+    const hasUserId = parts.length === 4;
+    const [workspaceIdText, maybeUserIdText, maybeIssuedAtText, signature] =
+      hasUserId ? parts : [parts[0], undefined, parts[1], parts[2]];
+    const issuedAtText = maybeIssuedAtText;
 
     if (!workspaceIdText || !issuedAtText || !signature) {
       console.warn('GitHub App callback received invalid workspace state', {
@@ -319,11 +338,13 @@ export class GithubService {
     }
 
     const workspaceId = Number(workspaceIdText);
+    const userId = maybeUserIdText ? Number(maybeUserIdText) : undefined;
     const issuedAt = Number(issuedAtText);
 
     if (
       !workspaceId ||
       Number.isNaN(workspaceId) ||
+      (maybeUserIdText && (!userId || Number.isNaN(userId))) ||
       !issuedAt ||
       Number.isNaN(issuedAt)
     ) {
@@ -341,7 +362,9 @@ export class GithubService {
       return undefined;
     }
 
-    const signedPayload = `${workspaceId}.${issuedAt}`;
+    const signedPayload = hasUserId
+      ? `${workspaceId}.${userId}.${issuedAt}`
+      : `${workspaceId}.${issuedAt}`;
     const expectedSignature = createHmac('sha256', this.appStateSecret)
       .update(signedPayload)
       .digest('hex');
@@ -359,10 +382,9 @@ export class GithubService {
     return workspaceId;
   }
 
-  private createInstallationStateToken(workspaceId: string): string {
-    const normalizedWorkspaceId = workspaceId.trim();
+  private createInstallationStateToken(state: GithubInstallationState): string {
     const issuedAt = Date.now();
-    const signedPayload = `${normalizedWorkspaceId}.${issuedAt}`;
+    const signedPayload = `${state.workspaceId}.${state.userId}.${issuedAt}`;
     const signature = createHmac('sha256', this.appStateSecret)
       .update(signedPayload)
       .digest('hex');

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -12,3 +12,4 @@ export * from './communication-socket.service';
 export * from './pr-review-reminder-scheduler.service';
 export * from './pull-request-review-reminder.service';
 export * from './redis.service';
+export * from './workspace-authorization.service';

--- a/api/src/services/issue-priority.service.ts
+++ b/api/src/services/issue-priority.service.ts
@@ -429,6 +429,30 @@ export class IssuePriorityService {
     return descriptionWithoutNote.replace(/^👀\s*/u, '').trimStart();
   }
 
+  public normalizePredictionInput(
+    prediction: Partial<IssuePriorityPrediction> | null | undefined,
+  ): IssuePriorityPrediction | null {
+    if (!prediction) {
+      return null;
+    }
+
+    const priority = normalizeIssuePriority(prediction.priority);
+    const reason = prediction.reason?.trim();
+
+    if (!priority || !reason) {
+      return null;
+    }
+
+    return {
+      priority,
+      reason,
+      estimatedHours: normalizeEstimatedHours(prediction.estimatedHours),
+      estimationConfidence: normalizeEstimationConfidence(
+        prediction.estimationConfidence,
+      ),
+    };
+  }
+
   public stripPredictionNote(description: string | null | undefined): string {
     if (!description) {
       return '';

--- a/api/src/services/queue.service.ts
+++ b/api/src/services/queue.service.ts
@@ -1,6 +1,7 @@
 import {BindingScope, injectable, service} from '@loopback/core';
 import {JobsOptions, Queue} from 'bullmq';
 import type {NewsFeedEventAction, NewsFeedSourceType} from '../models';
+import type {IssuePriorityPrediction} from './issue-priority.service';
 import {RedisService} from './redis.service';
 
 export const GITHUB_ISSUES_QUEUE_NAME = 'github-issues-queue';
@@ -20,6 +21,7 @@ export type CreateGithubIssueJobData = {
   repositoryId: number;
   title: string;
   description: string;
+  prediction?: IssuePriorityPrediction | null;
 };
 
 export type PrioritizeGithubPullRequestJobData = {

--- a/api/src/services/workspace-authorization.service.ts
+++ b/api/src/services/workspace-authorization.service.ts
@@ -1,0 +1,241 @@
+import {HttpErrors} from '@loopback/rest';
+import {repository, Filter, Where} from '@loopback/repository';
+import {securityId, UserProfile} from '@loopback/security';
+import {
+  WORKSPACE_MEMBER_ROLE,
+  WORKSPACE_PERMISSION,
+  WORKSPACE_ROLE,
+  WorkspaceMemberRole,
+  WorkspacePermission,
+  WorkspaceRole,
+} from '../constants';
+import {Workspace, WorkspaceMember} from '../models';
+import {WorkspaceMemberRepository, WorkspaceRepository} from '../repositories';
+
+export type WorkspacePermissionDecision = {
+  allowed: boolean;
+  permission: WorkspacePermission;
+  workspaceId: number;
+  role: WorkspaceRole | null;
+};
+
+const ADMIN_PERMISSIONS = new Set<WorkspacePermission>([
+  WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+  WORKSPACE_PERMISSION.WORKSPACE_MEMBERS_MANAGE,
+  WORKSPACE_PERMISSION.CAPACITY_PLAN_MANAGE,
+  WORKSPACE_PERMISSION.GITHUB_INSTALL_MANAGE,
+  WORKSPACE_PERMISSION.GITHUB_ISSUE_MANAGE,
+]);
+
+const OWNER_PERMISSIONS = new Set<WorkspacePermission>([
+  WORKSPACE_PERMISSION.WORKSPACE_DELETE,
+  WORKSPACE_PERMISSION.AI_SETTINGS_MANAGE,
+]);
+
+const MEMBER_PERMISSIONS = new Set<WorkspacePermission>([
+  WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+  WORKSPACE_PERMISSION.COMMUNICATION_VIEW,
+  WORKSPACE_PERMISSION.GITHUB_PULL_REQUEST_VIEW,
+]);
+
+export class WorkspaceAuthorizationService {
+  constructor(
+    @repository(WorkspaceRepository)
+    private workspaceRepository: WorkspaceRepository,
+    @repository(WorkspaceMemberRepository)
+    private workspaceMemberRepository: WorkspaceMemberRepository,
+  ) {}
+
+  getAuthenticatedUserId(userProfile: UserProfile | undefined): number {
+    const rawId = userProfile?.id ?? userProfile?.[securityId];
+    const userId =
+      typeof rawId === 'number' ? rawId : Number.parseInt(String(rawId), 10);
+
+    if (!Number.isFinite(userId)) {
+      throw new HttpErrors.Unauthorized('Missing authenticated user.');
+    }
+
+    return userId;
+  }
+
+  async checkPermission(
+    workspaceId: number,
+    userId: number,
+    permission: WorkspacePermission,
+  ): Promise<WorkspacePermissionDecision> {
+    const role = await this.getWorkspaceRole(workspaceId, userId);
+
+    return {
+      allowed: this.isAllowed(role, permission),
+      permission,
+      workspaceId,
+      role,
+    };
+  }
+
+  async assertPermission(
+    workspaceId: number,
+    userId: number,
+    permission: WorkspacePermission,
+  ): Promise<WorkspaceRole> {
+    const decision = await this.checkPermission(
+      workspaceId,
+      userId,
+      permission,
+    );
+
+    if (!decision.allowed || !decision.role) {
+      throw new HttpErrors.Forbidden(
+        'You do not have access to this workspace.',
+      );
+    }
+
+    return decision.role;
+  }
+
+  async assertWorkspaceMember(
+    workspaceId: number,
+    userId: number,
+  ): Promise<WorkspaceRole> {
+    return this.assertPermission(
+      workspaceId,
+      userId,
+      WORKSPACE_PERMISSION.WORKSPACE_VIEW,
+    );
+  }
+
+  async assertWorkspaceAdminOrOwner(
+    workspaceId: number,
+    userId: number,
+  ): Promise<WorkspaceRole> {
+    return this.assertPermission(
+      workspaceId,
+      userId,
+      WORKSPACE_PERMISSION.WORKSPACE_SETTINGS_MANAGE,
+    );
+  }
+
+  async assertWorkspaceOwner(
+    workspaceId: number,
+    userId: number,
+  ): Promise<WorkspaceRole> {
+    return this.assertPermission(
+      workspaceId,
+      userId,
+      WORKSPACE_PERMISSION.WORKSPACE_DELETE,
+    );
+  }
+
+  async getWorkspaceRole(
+    workspaceId: number,
+    userId: number,
+  ): Promise<WorkspaceRole | null> {
+    const workspace = await this.workspaceRepository.findById(workspaceId);
+
+    if (workspace.ownerId === userId) {
+      return WORKSPACE_ROLE.OWNER;
+    }
+
+    const membership = await this.workspaceMemberRepository.findOne({
+      where: {
+        workspaceId,
+        userId,
+      },
+    });
+
+    if (!membership) {
+      return null;
+    }
+
+    return this.mapMemberRole(membership.role);
+  }
+
+  async workspaceAccessWhere(userId: number): Promise<Where<Workspace>> {
+    const memberships = await this.workspaceMemberRepository.find({
+      where: {userId},
+    });
+    const workspaceIds = memberships
+      .map(member => member.workspaceId)
+      .filter((workspaceId): workspaceId is number => workspaceId != null);
+
+    return {
+      or: [{ownerId: userId}, {id: {inq: workspaceIds}}],
+    };
+  }
+
+  async accessibleWorkspaceIds(userId: number): Promise<number[]> {
+    const workspaces = await this.workspaceRepository.find({
+      where: await this.workspaceAccessWhere(userId),
+    });
+
+    return workspaces.map(workspace => workspace.id);
+  }
+
+  async mergeWorkspaceAccessFilter(
+    filter: Filter<Workspace> | undefined,
+    userId: number,
+  ): Promise<Filter<Workspace>> {
+    const accessWhere = await this.workspaceAccessWhere(userId);
+    const existingWhere = filter?.where;
+
+    return {
+      ...filter,
+      where: existingWhere ? {and: [existingWhere, accessWhere]} : accessWhere,
+    };
+  }
+
+  async mergeWorkspaceMemberAccessWhere(
+    where: Where<WorkspaceMember> | undefined,
+    userId: number,
+  ): Promise<Where<WorkspaceMember>> {
+    const accessWhere = await this.workspaceAccessWhere(userId);
+    const workspaces = await this.workspaceRepository.find({
+      where: accessWhere,
+    });
+    const workspaceIds = workspaces.map(workspace => workspace.id);
+    const membershipWhere: Where<WorkspaceMember> = {
+      workspaceId: {inq: workspaceIds},
+    };
+
+    return where ? {and: [where, membershipWhere]} : membershipWhere;
+  }
+
+  private isAllowed(
+    role: WorkspaceRole | null,
+    permission: WorkspacePermission,
+  ): boolean {
+    if (!role) {
+      return false;
+    }
+
+    if (role === WORKSPACE_ROLE.OWNER) {
+      return true;
+    }
+
+    if (OWNER_PERMISSIONS.has(permission)) {
+      return false;
+    }
+
+    if (role === WORKSPACE_ROLE.ADMIN) {
+      return (
+        ADMIN_PERMISSIONS.has(permission) || MEMBER_PERMISSIONS.has(permission)
+      );
+    }
+
+    return MEMBER_PERMISSIONS.has(permission);
+  }
+
+  private mapMemberRole(
+    role: WorkspaceMemberRole | undefined,
+  ): WorkspaceRole | null {
+    if (role === WORKSPACE_MEMBER_ROLE.ADMIN) {
+      return WORKSPACE_ROLE.ADMIN;
+    }
+
+    if (role === WORKSPACE_MEMBER_ROLE.MEMBER) {
+      return WORKSPACE_ROLE.MEMBER;
+    }
+
+    return null;
+  }
+}

--- a/api/src/workers/github.worker.ts
+++ b/api/src/workers/github.worker.ts
@@ -295,12 +295,14 @@ async function processCreateIssueJob(
     labelService,
   );
 
-  const prediction = await issuePriorityService.predictIssuePriority({
-    installationId,
-    repositoryFullName: repository.fullName,
-    title: job.data.title,
-    description: job.data.description,
-  });
+  const prediction =
+    job.data.prediction ??
+    (await issuePriorityService.predictIssuePriority({
+      installationId,
+      repositoryFullName: repository.fullName,
+      title: job.data.title,
+      description: job.data.description,
+    }));
   const githubIssue = await githubService.createIssue(
     installationId,
     repository.fullName,

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     fileParallelism: false,
+    globalSetup: './src/__tests__/global-setup.ts',
     include: ['src/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/client/app/components/routes/access-denied.gts
+++ b/client/app/components/routes/access-denied.gts
@@ -1,0 +1,35 @@
+import type { TOC } from '@ember/component/template-only';
+import { LinkTo } from '@ember/routing';
+import UiButton from 'client/components/ui/button';
+import UiContainer from 'client/components/ui/container';
+import UiIcon from 'client/components/ui/icon';
+
+interface RoutesAccessDeniedSignature {
+  Args: object;
+}
+
+const RoutesAccessDenied = <template>
+  <main class="route-access-denied">
+    <UiContainer @bordered={{true}} class="access-denied-panel">
+      <div class="access-denied-content layout-vertical --gap-lg">
+        <div class="access-denied-icon">
+          <UiIcon @name="lock" @size="xl" @variant="warning" />
+        </div>
+
+        <div class="layout-vertical --gap-sm">
+          <h1 class="margin-zero">Access denied</h1>
+          <p class="margin-zero font-color-text-secondary">
+            You do not have permission to view this area. Ask a workspace owner
+            or admin if you need access.
+          </p>
+        </div>
+
+        <LinkTo @route="workspaces.index">
+          <UiButton @text="Back to workspaces" @iconLeft="arrow-left" />
+        </LinkTo>
+      </div>
+    </UiContainer>
+  </main>
+</template> satisfies TOC<RoutesAccessDeniedSignature>;
+
+export default RoutesAccessDenied;

--- a/client/app/components/routes/workspaces/edit/access-denied.gts
+++ b/client/app/components/routes/workspaces/edit/access-denied.gts
@@ -1,0 +1,35 @@
+import type { TOC } from '@ember/component/template-only';
+import { LinkTo } from '@ember/routing';
+import UiButton from 'client/components/ui/button';
+import UiContainer from 'client/components/ui/container';
+import UiIcon from 'client/components/ui/icon';
+
+interface RoutesWorkspacesEditAccessDeniedSignature {
+  Args: object;
+}
+
+const RoutesWorkspacesEditAccessDenied = <template>
+  <section class="workspace-access-denied">
+    <UiContainer @bordered={{true}} class="access-denied-panel">
+      <div class="access-denied-content layout-vertical --gap-lg">
+        <div class="access-denied-icon">
+          <UiIcon @name="lock" @size="xl" @variant="warning" />
+        </div>
+
+        <div class="layout-vertical --gap-sm">
+          <h1 class="margin-zero">You cannot open this workspace area</h1>
+          <p class="margin-zero font-color-text-secondary">
+            This page is protected by workspace permissions. Nothing from the
+            restricted route was loaded.
+          </p>
+        </div>
+
+        <LinkTo @route="workspaces.index">
+          <UiButton @text="Back to workspaces" @iconLeft="arrow-left" />
+        </LinkTo>
+      </div>
+    </UiContainer>
+  </section>
+</template> satisfies TOC<RoutesWorkspacesEditAccessDeniedSignature>;
+
+export default RoutesWorkspacesEditAccessDenied;

--- a/client/app/components/routes/workspaces/edit/issues/new.gts
+++ b/client/app/components/routes/workspaces/edit/issues/new.gts
@@ -31,7 +31,7 @@ type ApiServiceLike = {
     path: string,
     options: {
       method: 'POST';
-      body: Record<string, number | string | null>;
+      body: Record<string, number | string | AnalyzeIssueResponse | null>;
     }
   ): Promise<AnalyzeIssueResponse | CreateIssueResponse>;
 };
@@ -173,6 +173,7 @@ export default class RoutesWorkspacesEditIssuesNew extends Component<RoutesWorks
           repositoryId: Number(this.selectedRepository.id),
           title: this.title.trim(),
           description: this.description.trim(),
+          prediction: this.analysisResult,
         },
       }
     )) as CreateIssueResponse;

--- a/client/app/components/routes/workspaces/new.gts
+++ b/client/app/components/routes/workspaces/new.gts
@@ -152,8 +152,10 @@ export default class RoutesWorkspacesNew extends Component<RoutesWorkspacesNewSi
   }
 
   redirectToGithubAppInstallation(workspaceId: number) {
+    const token = this.session.data.authenticated?.token;
     const installUrl = this.api.buildUrl('/github/installApp', {
       workspaceId: String(workspaceId),
+      ...(token ? { token: String(token) } : {}),
     });
     globalThis.location.assign(installUrl.toString());
   }

--- a/client/app/router.ts
+++ b/client/app/router.ts
@@ -13,6 +13,7 @@ Router.map(function () {
     this.route('callback');
   });
   this.route('profile');
+  this.route('access-denied');
   this.route('workspaces', function () {
     this.route('callback');
     this.route('new');
@@ -28,6 +29,7 @@ Router.map(function () {
       });
 
       this.route('settings');
+      this.route('access-denied');
       this.route('communication');
       this.route('news-feed', function () {
         this.route('issue', { path: '/issues/:issue_id' });

--- a/client/app/routes/protected.ts
+++ b/client/app/routes/protected.ts
@@ -1,0 +1,52 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import type RouterService from '@ember/routing/router-service';
+import type ApiService from 'client/services/api';
+
+type PermissionDecision = {
+  allowed: boolean;
+};
+
+type WorkspaceRouteModel = {
+  workspace?: {
+    id?: string | number | null;
+  } | null;
+};
+
+export default class ProtectedRoute extends Route {
+  @service declare api: ApiService;
+  @service declare router: RouterService;
+
+  async canAccessWorkspaceRoute(
+    workspaceId: number,
+    permission: string
+  ): Promise<boolean> {
+    const decision = (await this.api.request('/authorization/check', {
+      method: 'POST',
+      body: {
+        workspaceId,
+        permission,
+      },
+    })) as PermissionDecision;
+
+    return decision.allowed;
+  }
+
+  async requireWorkspacePermission(
+    workspaceId: number,
+    permission: string
+  ): Promise<boolean> {
+    const allowed = await this.canAccessWorkspaceRoute(workspaceId, permission);
+
+    if (!allowed) {
+      this.router.transitionTo('workspaces.index');
+    }
+
+    return allowed;
+  }
+
+  workspaceIdFromParentRoute(routeName = 'workspaces.edit'): number {
+    const parentModel = this.modelFor(routeName) as WorkspaceRouteModel;
+    return Number(parentModel.workspace?.id);
+  }
+}

--- a/client/app/routes/protected.ts
+++ b/client/app/routes/protected.ts
@@ -39,7 +39,14 @@ export default class ProtectedRoute extends Route {
     const allowed = await this.canAccessWorkspaceRoute(workspaceId, permission);
 
     if (!allowed) {
-      this.router.transitionTo('workspaces.index');
+      if (
+        this.routeName.startsWith('workspaces.edit.') &&
+        this.routeName !== 'workspaces.edit.access-denied'
+      ) {
+        this.router.transitionTo('workspaces.edit.access-denied', workspaceId);
+      } else {
+        this.router.transitionTo('access-denied');
+      }
     }
 
     return allowed;

--- a/client/app/routes/workspaces/edit.ts
+++ b/client/app/routes/workspaces/edit.ts
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type WorkspaceModel from 'client/models/workspace';
 import type GithubRepositoryModel from 'client/models/github-repository';
+import ProtectedRoute from 'client/routes/protected';
 
 type StoreLike = {
   findRecord(modelName: 'workspace', id: number): Promise<WorkspaceModel>;
@@ -20,12 +20,24 @@ export type WorkspacesIssuesRouteModel = {
   repositories: GithubRepositoryModel[];
 };
 
-export default class WorkspacesEditRoute extends Route {
+export default class WorkspacesEditRoute extends ProtectedRoute {
   @service declare store: StoreLike;
   @service declare lastWorkspace: LastWorkspaceServiceLike;
 
   async model(params: { id: string }): Promise<WorkspacesIssuesRouteModel> {
     const workspaceId = Number.parseInt(params.id, 10);
+
+    const canAccessWorkspace = await this.requireWorkspacePermission(
+      workspaceId,
+      'workspace.view'
+    );
+
+    if (!canAccessWorkspace) {
+      return {
+        workspace: undefined as never,
+        repositories: [],
+      };
+    }
 
     const workspace = await this.store.findRecord('workspace', workspaceId);
     const repositories = await this.store.query('github-repository', {

--- a/client/app/routes/workspaces/edit/capacity-planning.ts
+++ b/client/app/routes/workspaces/edit/capacity-planning.ts
@@ -1,4 +1,3 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type CapacityPlanEntryModel from 'client/models/capacity-plan-entry';
 import type CapacityPlanModel from 'client/models/capacity-plan';
@@ -9,6 +8,7 @@ import type UserModel from 'client/models/user';
 import type WorkspaceMemberModel from 'client/models/workspace-member';
 import type WorkspaceModel from 'client/models/workspace';
 import type { WorkspacesIssuesRouteModel } from 'client/routes/workspaces/edit';
+import ProtectedRoute from 'client/routes/protected';
 
 type StoreLike = {
   findRecord(modelName: 'user', id: number): Promise<UserModel>;
@@ -51,7 +51,7 @@ export type WorkspacesEditCapacityPlanningRouteModel = {
   issues: GithubIssueModel[];
 };
 
-export default class WorkspacesEditCapacityPlanningRoute extends Route {
+export default class WorkspacesEditCapacityPlanningRoute extends ProtectedRoute {
   @service declare store: StoreLike;
 
   async model(): Promise<WorkspacesEditCapacityPlanningRouteModel> {
@@ -61,6 +61,23 @@ export default class WorkspacesEditCapacityPlanningRoute extends Route {
     const workspace = workspacesEditModel.workspace;
     const repositories = workspacesEditModel.repositories;
     const workspaceId = Number(workspace.id);
+    const canManageCapacityPlanning = await this.requireWorkspacePermission(
+      workspaceId,
+      'capacity-plan.manage'
+    );
+
+    if (!canManageCapacityPlanning) {
+      return {
+        workspace,
+        repositories,
+        plans: [],
+        entries: [],
+        issueAssignments: [],
+        teamMembers: [],
+        issues: [],
+      };
+    }
+
     const repositoryIds = repositories.map((repository) =>
       Number(repository.id)
     );

--- a/client/app/routes/workspaces/edit/communication.ts
+++ b/client/app/routes/workspaces/edit/communication.ts
@@ -1,9 +1,9 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type WorkspaceModel from 'client/models/workspace';
 import type WorkspaceMemberModel from 'client/models/workspace-member';
 import type UserModel from 'client/models/user';
 import type { WorkspacesIssuesRouteModel } from 'client/routes/workspaces/edit';
+import ProtectedRoute from 'client/routes/protected';
 import type ApiService from 'client/services/api';
 
 type StoreLike = {
@@ -81,7 +81,7 @@ type JsonApiDocument = {
   included?: JsonApiResource[];
 };
 
-export default class WorkspacesEditCommunicationRoute extends Route {
+export default class WorkspacesEditCommunicationRoute extends ProtectedRoute {
   @service declare store: StoreLike;
   @service declare api: ApiService;
 
@@ -99,6 +99,19 @@ export default class WorkspacesEditCommunicationRoute extends Route {
     ) as WorkspacesIssuesRouteModel;
     const workspace = workspacesEditModel.workspace;
     const workspaceId = Number(workspace.id);
+    const canAccessCommunication = await this.requireWorkspacePermission(
+      workspaceId,
+      'communication.view'
+    );
+
+    if (!canAccessCommunication) {
+      return {
+        workspace,
+        members: [],
+        channels: [],
+        selectedChannelId: null,
+      };
+    }
 
     const [members, owner, channelsPayload] = await Promise.all([
       this.store.query('workspace-member', {

--- a/client/app/routes/workspaces/edit/issues/edit.ts
+++ b/client/app/routes/workspaces/edit/issues/edit.ts
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type GithubIssueModel from 'client/models/github-issue';
+import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesEditIssuesRouteModel } from 'client/routes/workspaces/edit/issues';
 
 type StoreLike = {
@@ -16,7 +16,7 @@ export type WorkspacesEditIssuesEditRouteModel = {
   repositoryName: string | null;
 };
 
-export default class WorkspacesEditIssuesEditRoute extends Route {
+export default class WorkspacesEditIssuesEditRoute extends ProtectedRoute {
   @service declare store: StoreLike;
 
   async model(params: {
@@ -25,6 +25,16 @@ export default class WorkspacesEditIssuesEditRoute extends Route {
     const issuesModel = this.modelFor(
       'workspaces.edit.issues'
     ) as WorkspacesEditIssuesRouteModel;
+    const workspaceId = Number(issuesModel.workspace.id);
+    const canManageIssues = await this.requireWorkspacePermission(
+      workspaceId,
+      'github.issue.manage'
+    );
+
+    if (!canManageIssues) {
+      return undefined as never;
+    }
+
     const [issue] = await this.store.query('github-issue', {
       filter: {
         include: ['aiPrediction'],
@@ -44,7 +54,7 @@ export default class WorkspacesEditIssuesEditRoute extends Route {
     );
 
     return {
-      workspaceId: Number(issuesModel.workspace.id),
+      workspaceId,
       issue,
       repositoryName: repository?.name ?? null,
     };

--- a/client/app/routes/workspaces/edit/issues/new.ts
+++ b/client/app/routes/workspaces/edit/issues/new.ts
@@ -1,8 +1,18 @@
-import Route from '@ember/routing/route';
+import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesEditIssuesRouteModel } from 'client/routes/workspaces/edit/issues';
 
-export default class WorkspacesEditIssuesNewRoute extends Route {
-  model(): WorkspacesEditIssuesNewRouteModel {
+export default class WorkspacesEditIssuesNewRoute extends ProtectedRoute {
+  async model(): Promise<WorkspacesEditIssuesNewRouteModel> {
+    const workspaceId = this.workspaceIdFromParentRoute();
+    const canManageIssues = await this.requireWorkspacePermission(
+      workspaceId,
+      'github.issue.manage'
+    );
+
+    if (!canManageIssues) {
+      return undefined as never;
+    }
+
     return this.modelFor(
       'workspaces.edit.issues'
     ) as WorkspacesEditIssuesNewRouteModel;

--- a/client/app/routes/workspaces/edit/news-feed.ts
+++ b/client/app/routes/workspaces/edit/news-feed.ts
@@ -1,10 +1,9 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type GithubRepositoryModel from 'client/models/github-repository';
 import type NewsFeedEntryModel from 'client/models/news-feed-entry';
 import type WorkspaceModel from 'client/models/workspace';
-import type SessionAccountService from 'client/services/session-account';
 import type { WorkspacesIssuesRouteModel } from 'client/routes/workspaces/edit';
+import ProtectedRoute from 'client/routes/protected';
 
 type StoreLike = {
   query(
@@ -19,23 +18,31 @@ export type WorkspacesEditNewsFeedRouteModel = {
   entries: NewsFeedEntryModel[];
 };
 
-export default class WorkspacesEditNewsFeedRoute extends Route {
+export default class WorkspacesEditNewsFeedRoute extends ProtectedRoute {
   @service declare store: StoreLike;
-  @service declare sessionAccount: SessionAccountService;
 
   async model(): Promise<WorkspacesEditNewsFeedRouteModel> {
     const workspacesEditModel = this.modelFor(
       'workspaces.edit'
     ) as WorkspacesIssuesRouteModel;
     const workspace = workspacesEditModel.workspace;
-    const userId = Number(this.sessionAccount.id);
+    const workspaceId = Number(workspace.id);
+    const canAccessNewsFeed = await this.requireWorkspacePermission(
+      workspaceId,
+      'workspace.view'
+    );
+
+    if (!canAccessNewsFeed) {
+      return {
+        workspace,
+        repositories: workspacesEditModel.repositories,
+        entries: [],
+      };
+    }
 
     const entries =
-      Number.isFinite(userId) && userId > 0
-        ? await this.store.query('news-feed-entry', {
-            workspaceId: Number(workspace.id),
-            userId,
-          })
+      Number.isFinite(workspaceId) && workspaceId > 0
+        ? await this.store.query('news-feed-entry', { workspaceId })
         : [];
 
     return {

--- a/client/app/routes/workspaces/edit/pull-requests/edit.ts
+++ b/client/app/routes/workspaces/edit/pull-requests/edit.ts
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type GithubPullRequestModel from 'client/models/github-pull-request';
+import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesEditPullRequestsRouteModel } from 'client/routes/workspaces/edit/pull-requests';
 
 type StoreLike = {
@@ -17,7 +17,7 @@ export type WorkspacesEditPullRequestsEditRouteModel = {
   repositoryFullName: string | null;
 };
 
-export default class WorkspacesEditPullRequestsEditRoute extends Route {
+export default class WorkspacesEditPullRequestsEditRoute extends ProtectedRoute {
   @service declare store: StoreLike;
 
   async model(params: {
@@ -26,6 +26,16 @@ export default class WorkspacesEditPullRequestsEditRoute extends Route {
     const pullRequestsModel = this.modelFor(
       'workspaces.edit.pull-requests'
     ) as WorkspacesEditPullRequestsRouteModel;
+    const workspaceId = Number(pullRequestsModel.workspace.id);
+    const canViewPullRequests = await this.requireWorkspacePermission(
+      workspaceId,
+      'github.pull-request.view'
+    );
+
+    if (!canViewPullRequests) {
+      return undefined as never;
+    }
+
     const [pullRequest] = await this.store.query('github-pull-request', {
       filter: {
         include: ['aiPrediction'],
@@ -47,7 +57,7 @@ export default class WorkspacesEditPullRequestsEditRoute extends Route {
     );
 
     return {
-      workspaceId: Number(pullRequestsModel.workspace.id),
+      workspaceId,
       pullRequest,
       repositoryName: repository?.name ?? null,
       repositoryFullName: repository?.fullName ?? null,

--- a/client/app/routes/workspaces/edit/settings.ts
+++ b/client/app/routes/workspaces/edit/settings.ts
@@ -1,9 +1,19 @@
-import Route from '@ember/routing/route';
 import type WorkspaceModel from 'client/models/workspace';
+import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesIssuesRouteModel } from 'client/routes/workspaces/edit';
 
-export default class WorkspacesEditSettingsRoute extends Route {
-  model(): WorkspaceModel {
+export default class WorkspacesEditSettingsRoute extends ProtectedRoute {
+  async model(): Promise<WorkspaceModel> {
+    const workspaceId = this.workspaceIdFromParentRoute();
+    const canAccessSettings = await this.requireWorkspacePermission(
+      workspaceId,
+      'workspace.settings.manage'
+    );
+
+    if (!canAccessSettings) {
+      return undefined as never;
+    }
+
     return (this.modelFor('workspaces.edit') as WorkspacesIssuesRouteModel)
       .workspace;
   }

--- a/client/app/styles/app.css
+++ b/client/app/styles/app.css
@@ -16,6 +16,7 @@
 @import url('ui/loading-spinner.css');
 
 @import url('routes/login.css');
+@import url('routes/access-denied.css');
 @import url('routes/workspaces/index.css');
 @import url('routes/workspaces/new.css');
 @import url('routes/workspaces/edit.css');

--- a/client/app/styles/routes/access-denied.css
+++ b/client/app/styles/routes/access-denied.css
@@ -1,0 +1,34 @@
+.route-access-denied,
+.workspace-access-denied {
+  display: grid;
+  min-height: 100dvh;
+  place-items: center;
+  padding: var(--space-xl);
+}
+
+.workspace-access-denied {
+  min-height: 100%;
+}
+
+.access-denied-panel {
+  width: min(34rem, 100%);
+}
+
+.access-denied-content {
+  align-items: center;
+  text-align: center;
+}
+
+.access-denied-icon {
+  display: grid;
+  width: 4.5rem;
+  height: 4.5rem;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-muted);
+}
+
+.access-denied-content p {
+  max-width: 28rem;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@loopback/authentication-jwt':
         specifier: ^0.16.11
         version: 0.16.11(@loopback/authentication@12.0.11(@loopback/core@7.0.8)(@loopback/rest@15.0.9(@loopback/core@7.0.8)(@loopback/repository@8.0.8(@loopback/core@7.0.8))))(@loopback/core@7.0.8)(@loopback/rest@15.0.9(@loopback/core@7.0.8)(@loopback/repository@8.0.8(@loopback/core@7.0.8)))
+      '@loopback/authorization':
+        specifier: ^0.16.12
+        version: 0.16.12(@loopback/core@7.0.8)
       '@loopback/boot':
         specifier: ^8.0.5
         version: 8.0.9(@loopback/core@7.0.8)
@@ -1849,6 +1852,12 @@ packages:
       '@loopback/core': ^7.0.0
       '@loopback/rest': ^15.0.0
 
+  '@loopback/authorization@0.16.12':
+    resolution: {integrity: sha512-2tLpKZ1UHRbaMXgOkUXJ9+JHCl0HtFuakYLAqJ92ktOqE+1BtwEuqOheUWhCui+a96bj/dtl2Hof3whLj5/Fww==}
+    engines: {node: 20 || 22 || 24}
+    peerDependencies:
+      '@loopback/core': ^7.0.0
+
   '@loopback/boot@8.0.9':
     resolution: {integrity: sha512-t467VUPh1Bt1N9Ogt7Wu/EpOJ769F593Zw4vuk3zckyYkWesTGq/BY0n4EuamkkfCsWUmTi+lCOYEAHqUu61OQ==}
     engines: {node: 20 || 22 || 24}
@@ -1939,6 +1948,12 @@ packages:
 
   '@loopback/security@0.12.10':
     resolution: {integrity: sha512-GE6RX8fkW7A/E7YwVCWbicaGzJsXHRlGwR/oQgdqFjN3VpXaeVXKxROO+hQKDX1xzsgfmOIpJ6Zg/qqtupTo7g==}
+    engines: {node: 20 || 22 || 24}
+    peerDependencies:
+      '@loopback/core': ^7.0.1
+
+  '@loopback/security@0.12.12':
+    resolution: {integrity: sha512-OIpub3xm047ZxKPwMAzlVoZaccF+HcRRCXMdNoj5LA0Umt/J41vlpT387blvzxvb1fkS0FejSvjAX6mcUuC4xw==}
     engines: {node: 20 || 22 || 24}
     peerDependencies:
       '@loopback/core': ^7.0.1
@@ -11038,6 +11053,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@loopback/authorization@0.16.12(@loopback/core@7.0.8)':
+    dependencies:
+      '@loopback/core': 7.0.8
+      '@loopback/security': 0.12.12(@loopback/core@7.0.8)
+      debug: 4.4.3(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@loopback/boot@8.0.9(@loopback/core@7.0.8)':
     dependencies:
       '@loopback/core': 7.0.8
@@ -11241,6 +11265,14 @@ snapshots:
       - supports-color
 
   '@loopback/security@0.12.10(@loopback/core@7.0.8)':
+    dependencies:
+      '@loopback/core': 7.0.8
+      debug: 4.4.3(supports-color@8.1.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@loopback/security@0.12.12(@loopback/core@7.0.8)':
     dependencies:
       '@loopback/core': 7.0.8
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
## Summary

This PR implements workspace-based RBAC authorization across the application.

It adds backend permission checks, workspace-scoped query filtering, and frontend route protection so users can only access or modify resources that belong to workspaces they own or are members of.

## What changed

- Added `@loopback/authorization` as a backend dependency.
- Added workspace permission and role constants for:
  - workspace viewing and management
  - member management
  - GitHub installation management
  - GitHub issue management
  - GitHub pull request viewing
  - AI settings management
  - capacity planning management
  - communication access
- Added `WorkspaceAuthorizationService` for:
  - resolving authenticated user IDs
  - checking permissions
  - asserting member/admin/owner access
  - resolving workspace roles
  - building workspace access filters
  - merging authorization constraints into existing queries
- Added a workspace authorizer provider for LoopBack authorization integration.
- Added an authorization controller endpoint that frontend route guards can call to verify access.
- Updated controllers to enforce permissions before reading, creating, updating, or deleting protected resources.
- Added query-level filtering so list endpoints only return resources from workspaces the current user can access.
- Protected GitHub integration, issues, pull requests, repositories, planning, invitations, workspace members, news feed, expertise, and workspace settings routes.
- Updated frontend protected workspace routes to check backend authorization before loading restricted pages.
- Updated serializers/deserializers and related controller tests to support the new authorization-aware request flow.
- Added and updated unit tests for RBAC logic, authorization controller behavior, controller-level access checks, and workspace-scoped filtering.

## Why

Before this change, workspace-related resources could be accessed through API queries without consistently enforcing workspace membership or role permissions.

This PR centralizes authorization logic and applies it consistently, making workspace ownership, admin rights, and member access explicit across both backend APIs and frontend route navigation.

## Testing

Added or updated unit test coverage for:

- workspace permission checks
- owner/admin/member role behavior
- authorization controller decisions
- workspace-scoped query filtering
- GitHub controller permission checks
- issue and pull request access restrictions
- invitation creation and listing authorization
- planning and capacity management authorization
- workspace member and workspace controller access rules
- frontend route guard behavior

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: High
> Reason: This PR introduces significant RBAC authorization logic with workspace-scoped query filtering across many controllers and repositories. The primary risk comes from the breadth of changes touching core data access patterns, including new migrations, authorization interceptors, and extensive controller modifications. While well-tested, the scope for unintended access bypass or performance regressions due to complex query merging is elevated.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->