### PR TITLE
Sync GitHub assignees into planning

### DIFF
--- a/api/src/__tests__/unit/services/capacity-planning-sync.service.test.ts
+++ b/api/src/__tests__/unit/services/capacity-planning-sync.service.test.ts
@@ -210,6 +210,140 @@ describe('CapacityPlanningSyncService (unit)', () => {
     );
   });
 
+  it('ignores GitHub assignee changes when the assignee identity is missing', async () => {
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {login: '   '},
+    });
+
+    expect(githubRepositoryRepository.findById).not.toHaveBeenCalled();
+    expect(githubIssueRepository.findOne).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('skips incoming GitHub assignee sync when the issue is not stored locally', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue(null);
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Skipping GitHub assignee sync because the issue is not stored locally.',
+      {
+        repositoryId: 4,
+        githubIssueId: 22,
+        githubIssueNumber: 27,
+      },
+    );
+    expect(workspaceRepository.findById).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to login matching and the latest plan when importing GitHub assignments', async () => {
+    capacityPlanRepository.findOne = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({id: 9, workspaceId: 3});
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    userRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({id: 6, githubId: 222, username: 'fallback-user'});
+    issueAssignmentRepository.create.mockResolvedValue({id: 20});
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 222, login: 'fallback-user'},
+    });
+
+    expect(userRepository.findOne).toHaveBeenNthCalledWith(1, {
+      where: {githubId: 222},
+    });
+    expect(userRepository.findOne).toHaveBeenNthCalledWith(2, {
+      where: {username: 'fallback-user'},
+    });
+    expect(capacityPlanRepository.findOne).toHaveBeenNthCalledWith(2, {
+      where: {workspaceId: 3},
+      order: ['start DESC'],
+    });
+    expect(issueAssignmentRepository.create).toHaveBeenCalledWith({
+      capacityPlanId: 9,
+      issueId: 11,
+      userId: 6,
+      assignedHours: 0,
+    });
+    expect(auditEventService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 6,
+        action: 'capacity-planning.assignment.imported',
+        resourceId: '20',
+      }),
+    );
+  });
+
+  it('does not import duplicate GitHub assignments into the active plan', async () => {
+    capacityPlanRepository.findOne = vi.fn().mockResolvedValue({
+      id: 8,
+      workspaceId: 3,
+    });
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    issueAssignmentRepository.findOne.mockResolvedValue({
+      id: 19,
+      capacityPlanId: 8,
+      issueId: 11,
+      userId: 5,
+    });
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+
   it('removes GitHub unassignments from the current capacity plan', async () => {
     capacityPlanRepository.findOne = vi.fn().mockResolvedValue({
       id: 8,
@@ -252,6 +386,36 @@ describe('CapacityPlanningSyncService (unit)', () => {
         source: 'github',
       }),
     );
+  });
+
+  it('does not audit GitHub unassignments when no local assignment exists', async () => {
+    capacityPlanRepository.findOne = vi.fn().mockResolvedValue({
+      id: 8,
+      workspaceId: 3,
+    });
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    issueAssignmentRepository.findOne.mockResolvedValue(null);
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'unassigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
   });
 
   it('skips incoming GitHub assignee sync when workspace sync is disabled', async () => {
@@ -306,6 +470,36 @@ describe('CapacityPlanningSyncService (unit)', () => {
       assignee: {id: 999, login: 'unknown'},
     });
 
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+
+  it('skips incoming GitHub assignee sync when GitHub id is unmapped and no login is available', async () => {
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    userRepository.findOne.mockResolvedValue(null);
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 999},
+    });
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({
+      where: {githubId: 999},
+    });
     expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
     expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
     expect(auditEventService.record).not.toHaveBeenCalled();

--- a/api/src/__tests__/unit/services/capacity-planning-sync.service.test.ts
+++ b/api/src/__tests__/unit/services/capacity-planning-sync.service.test.ts
@@ -4,10 +4,24 @@ import {IssueAssignment} from '../../../models';
 import {CapacityPlanningSyncService} from '../../../services/capacity-planning-sync.service';
 
 describe('CapacityPlanningSyncService (unit)', () => {
-  let capacityPlanRepository: {findById: ReturnType<typeof vi.fn>};
-  let githubIssueRepository: {findById: ReturnType<typeof vi.fn>};
+  let capacityPlanRepository: {
+    findById: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+  };
+  let githubIssueRepository: {
+    findById: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+  };
   let githubRepositoryRepository: {findById: ReturnType<typeof vi.fn>};
-  let userRepository: {findById: ReturnType<typeof vi.fn>};
+  let issueAssignmentRepository: {
+    findOne: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    deleteById: ReturnType<typeof vi.fn>;
+  };
+  let userRepository: {
+    findById: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+  };
   let workspaceRepository: {findById: ReturnType<typeof vi.fn>};
   let githubService: {setIssueAssignees: ReturnType<typeof vi.fn>};
   let auditEventService: {record: ReturnType<typeof vi.fn>};
@@ -16,17 +30,38 @@ describe('CapacityPlanningSyncService (unit)', () => {
   beforeEach(() => {
     capacityPlanRepository = {
       findById: vi.fn().mockResolvedValue({id: 8, workspaceId: 3}),
+      findOne: vi.fn().mockResolvedValue({id: 8, workspaceId: 3}),
     };
     githubIssueRepository = {
       findById: vi
         .fn()
         .mockResolvedValue({id: 11, repositoryId: 4, githubIssueNumber: 27}),
+      findOne: vi.fn().mockResolvedValue({
+        id: 11,
+        repositoryId: 4,
+        githubId: 22,
+        githubIssueNumber: 27,
+      }),
     };
     githubRepositoryRepository = {
       findById: vi.fn().mockResolvedValue({id: 4, fullName: 'team/api'}),
     };
+    issueAssignmentRepository = {
+      findOne: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({id: 19}),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+    };
     userRepository = {
-      findById: vi.fn().mockResolvedValue({id: 5, username: 'octocat'}),
+      findById: vi.fn().mockResolvedValue({
+        id: 5,
+        githubId: 111,
+        username: 'octocat',
+      }),
+      findOne: vi.fn().mockResolvedValue({
+        id: 5,
+        githubId: 111,
+        username: 'octocat',
+      }),
     };
     workspaceRepository = {
       findById: vi.fn().mockResolvedValue({
@@ -46,6 +81,7 @@ describe('CapacityPlanningSyncService (unit)', () => {
       capacityPlanRepository as never,
       githubIssueRepository as never,
       githubRepositoryRepository as never,
+      issueAssignmentRepository as never,
       userRepository as never,
       workspaceRepository as never,
       githubService as never,
@@ -119,6 +155,186 @@ describe('CapacityPlanningSyncService (unit)', () => {
     );
 
     expect(githubService.setIssueAssignees).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+
+  it('imports GitHub assignee changes into the current capacity plan', async () => {
+    capacityPlanRepository.findOne = vi.fn().mockResolvedValue({
+      id: 8,
+      workspaceId: 3,
+    });
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne = vi.fn().mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+      aiPrediction: {estimatedHours: 6},
+    });
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(capacityPlanRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        workspaceId: 3,
+        start: {lte: expect.any(String)},
+        end: {gte: expect.any(String)},
+      },
+      order: ['start DESC'],
+    });
+    expect(issueAssignmentRepository.create).toHaveBeenCalledWith({
+      capacityPlanId: 8,
+      issueId: 11,
+      userId: 5,
+      assignedHours: 6,
+    });
+    expect(auditEventService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 5,
+        workspaceId: 3,
+        action: 'capacity-planning.assignment.imported',
+        resourceType: 'issue-assignment',
+        resourceId: '19',
+        source: 'github',
+      }),
+    );
+  });
+
+  it('removes GitHub unassignments from the current capacity plan', async () => {
+    capacityPlanRepository.findOne = vi.fn().mockResolvedValue({
+      id: 8,
+      workspaceId: 3,
+    });
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne = vi.fn().mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    issueAssignmentRepository.findOne.mockResolvedValue({
+      id: 19,
+      capacityPlanId: 8,
+      issueId: 11,
+      userId: 5,
+    });
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'unassigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(issueAssignmentRepository.deleteById).toHaveBeenCalledWith(19);
+    expect(auditEventService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: 5,
+        workspaceId: 3,
+        action: 'capacity-planning.assignment.removed-from-github',
+        resourceType: 'issue-assignment',
+        resourceId: '19',
+        source: 'github',
+      }),
+    );
+  });
+
+  it('skips incoming GitHub assignee sync when workspace sync is disabled', async () => {
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne = vi.fn().mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    workspaceRepository.findById.mockResolvedValue({
+      id: 3,
+      capacityPlanningSync: false,
+    });
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+
+  it('skips incoming GitHub assignee sync when the GitHub user is unknown', async () => {
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    userRepository.findOne.mockResolvedValue(null);
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 999, login: 'unknown'},
+    });
+
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+
+  it('skips incoming GitHub assignee sync when the workspace has no capacity plan', async () => {
+    githubRepositoryRepository.findById.mockResolvedValue({
+      id: 4,
+      workspaceId: 3,
+      fullName: 'team/api',
+    });
+    githubIssueRepository.findOne.mockResolvedValue({
+      id: 11,
+      repositoryId: 4,
+      githubId: 22,
+      githubIssueNumber: 27,
+    });
+    capacityPlanRepository.findOne.mockResolvedValue(null);
+
+    await service.syncGithubIssueAssigneeChange({
+      action: 'assigned',
+      repositoryId: 4,
+      githubIssueId: 22,
+      githubIssueNumber: 27,
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(issueAssignmentRepository.create).not.toHaveBeenCalled();
+    expect(issueAssignmentRepository.deleteById).not.toHaveBeenCalled();
     expect(auditEventService.record).not.toHaveBeenCalled();
   });
 });

--- a/api/src/__tests__/unit/services/github-webhook.service.test.ts
+++ b/api/src/__tests__/unit/services/github-webhook.service.test.ts
@@ -382,6 +382,113 @@ describe('GithubWebhookService (unit)', () => {
     expect(issueService.upsertIssue).not.toHaveBeenCalled();
   });
 
+  it('syncs GitHub issue unassignments into capacity planning', async () => {
+    await service.handleWebhook('issues', {
+      action: 'unassigned',
+      sender: {
+        login: 'octocat',
+        type: 'User',
+      },
+      repository: {
+        owner: {login: 'team'},
+        name: 'api',
+        full_name: 'team/api',
+      },
+      issue: {
+        id: 11,
+        node_id: 'node-1',
+        number: 101,
+        title: 'Broken',
+        body: 'Updated body',
+        state: 'open',
+      },
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(
+      capacityPlanningSyncService.syncGithubIssueAssigneeChange,
+    ).toHaveBeenCalledWith({
+      action: 'unassigned',
+      repositoryId: 99,
+      githubIssueId: 11,
+      githubIssueNumber: 101,
+      assignee: {id: 111, login: 'octocat'},
+    });
+    expect(issuePriorityService.predictIssuePriority).not.toHaveBeenCalled();
+    expect(issueService.upsertIssue).not.toHaveBeenCalled();
+  });
+
+  it('ignores issue assignee changes when repository identity is missing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await service.handleWebhook('issues', {
+      action: 'assigned',
+      sender: {
+        login: 'octocat',
+        type: 'User',
+      },
+      issue: {
+        id: 11,
+        node_id: 'node-1',
+        number: 101,
+        title: 'Broken',
+        body: 'Updated body',
+        state: 'open',
+      },
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'GitHub webhook payload missing repository full name',
+      {action: 'assigned'},
+    );
+    expect(
+      capacityPlanningSyncService.syncGithubIssueAssigneeChange,
+    ).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('ignores issue assignee changes when the repository is not synced', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    githubRepositoryRepository.findOne.mockResolvedValueOnce(null);
+
+    await service.handleWebhook('issues', {
+      action: 'assigned',
+      sender: {
+        login: 'octocat',
+        type: 'User',
+      },
+      repository: {
+        owner: {login: 'team'},
+        name: 'unknown',
+        full_name: 'team/unknown',
+      },
+      issue: {
+        id: 11,
+        node_id: 'node-1',
+        number: 101,
+        title: 'Broken',
+        body: 'Updated body',
+        state: 'open',
+      },
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'No synced GitHub repository found for webhook payload',
+      {
+        fullName: 'team/unknown',
+        action: 'assigned',
+      },
+    );
+    expect(
+      capacityPlanningSyncService.syncGithubIssueAssigneeChange,
+    ).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it('ignores GitHub issue assignee changes authored by the app bot', async () => {
     await service.handleWebhook('issues', {
       action: 'unassigned',

--- a/api/src/__tests__/unit/services/github-webhook.service.test.ts
+++ b/api/src/__tests__/unit/services/github-webhook.service.test.ts
@@ -29,6 +29,9 @@ describe('GithubWebhookService (unit)', () => {
     syncRequestedReviewers: ReturnType<typeof vi.fn>;
     markProgress: ReturnType<typeof vi.fn>;
   };
+  let capacityPlanningSyncService: {
+    syncGithubIssueAssigneeChange: ReturnType<typeof vi.fn>;
+  };
   let githubRepositoryRepository: {
     findOne: ReturnType<typeof vi.fn>;
   };
@@ -79,6 +82,9 @@ describe('GithubWebhookService (unit)', () => {
       syncRequestedReviewers: vi.fn().mockResolvedValue(undefined),
       markProgress: vi.fn().mockResolvedValue(undefined),
     };
+    capacityPlanningSyncService = {
+      syncGithubIssueAssigneeChange: vi.fn().mockResolvedValue(undefined),
+    };
     githubRepositoryRepository = {
       findOne: vi.fn().mockResolvedValue({
         id: 99,
@@ -96,6 +102,7 @@ describe('GithubWebhookService (unit)', () => {
       issueService as never,
       pullRequestService as never,
       pullRequestReviewerService as never,
+      capacityPlanningSyncService as never,
       githubRepositoryRepository as never,
       userRepository as never,
     );
@@ -337,6 +344,70 @@ describe('GithubWebhookService (unit)', () => {
     expect(issueService.upsertIssue).not.toHaveBeenCalled();
     expect(issuePriorityService.predictIssuePriority).not.toHaveBeenCalled();
     expect(githubService.applyPriorityPredictionToIssue).not.toHaveBeenCalled();
+  });
+
+  it('syncs GitHub issue assignee changes into capacity planning', async () => {
+    await service.handleWebhook('issues', {
+      action: 'assigned',
+      sender: {
+        login: 'octocat',
+        type: 'User',
+      },
+      repository: {
+        owner: {login: 'team'},
+        name: 'api',
+        full_name: 'team/api',
+      },
+      issue: {
+        id: 11,
+        node_id: 'node-1',
+        number: 101,
+        title: 'Broken',
+        body: 'Updated body',
+        state: 'open',
+      },
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(
+      capacityPlanningSyncService.syncGithubIssueAssigneeChange,
+    ).toHaveBeenCalledWith({
+      action: 'assigned',
+      repositoryId: 99,
+      githubIssueId: 11,
+      githubIssueNumber: 101,
+      assignee: {id: 111, login: 'octocat'},
+    });
+    expect(issuePriorityService.predictIssuePriority).not.toHaveBeenCalled();
+    expect(issueService.upsertIssue).not.toHaveBeenCalled();
+  });
+
+  it('ignores GitHub issue assignee changes authored by the app bot', async () => {
+    await service.handleWebhook('issues', {
+      action: 'unassigned',
+      sender: {
+        login: 'devteams-demo[bot]',
+        type: 'Bot',
+      },
+      repository: {
+        owner: {login: 'team'},
+        name: 'api',
+        full_name: 'team/api',
+      },
+      issue: {
+        id: 11,
+        node_id: 'node-1',
+        number: 101,
+        title: 'Broken',
+        body: 'Updated body',
+        state: 'open',
+      },
+      assignee: {id: 111, login: 'octocat'},
+    });
+
+    expect(
+      capacityPlanningSyncService.syncGithubIssueAssigneeChange,
+    ).not.toHaveBeenCalled();
   });
 
   it('upserts pull requests on pull request updates', async () => {

--- a/api/src/services/capacity-planning-sync.service.ts
+++ b/api/src/services/capacity-planning-sync.service.ts
@@ -1,15 +1,29 @@
 import {BindingScope, injectable, service} from '@loopback/core';
 import {repository} from '@loopback/repository';
-import {IssueAssignment} from '../models';
+import {CapacityPlan, GithubIssue, IssueAssignment} from '../models';
 import {
   CapacityPlanRepository,
   GithubIssueRepository,
   GithubRepositoryRepository,
+  IssueAssignmentRepository,
   UserRepository,
   WorkspaceRepository,
 } from '../repositories';
 import {GithubService} from './github-integration/github.service';
 import {AuditEventService} from './audit-event.service';
+
+type GithubAssigneeIdentity = {
+  id?: number;
+  login?: string;
+};
+
+type GithubIssueAssigneeSyncInput = {
+  action: 'assigned' | 'unassigned';
+  repositoryId: number;
+  githubIssueId: number;
+  githubIssueNumber: number;
+  assignee?: GithubAssigneeIdentity | null;
+};
 
 @injectable({scope: BindingScope.SINGLETON})
 export class CapacityPlanningSyncService {
@@ -20,6 +34,8 @@ export class CapacityPlanningSyncService {
     private githubIssueRepository: GithubIssueRepository,
     @repository(GithubRepositoryRepository)
     private githubRepositoryRepository: GithubRepositoryRepository,
+    @repository(IssueAssignmentRepository)
+    private issueAssignmentRepository: IssueAssignmentRepository,
     @repository(UserRepository)
     private userRepository: UserRepository,
     @repository(WorkspaceRepository)
@@ -64,6 +80,234 @@ export class CapacityPlanningSyncService {
         githubIssueNumber: issue.githubIssueNumber,
         repositoryFullName: githubRepository.fullName,
         assignee: user.username,
+      },
+    });
+  }
+
+  async syncGithubIssueAssigneeChange({
+    action,
+    repositoryId,
+    githubIssueId,
+    githubIssueNumber,
+    assignee,
+  }: GithubIssueAssigneeSyncInput): Promise<void> {
+    if (!assignee?.id && !assignee?.login?.trim()) {
+      return;
+    }
+
+    const [githubRepository, issue] = await Promise.all([
+      this.githubRepositoryRepository.findById(repositoryId),
+      this.githubIssueRepository.findOne({
+        where: {
+          repositoryId,
+          githubId: githubIssueId,
+        },
+        include: ['aiPrediction'],
+      }),
+    ]);
+
+    if (!issue) {
+      console.warn(
+        'Skipping GitHub assignee sync because the issue is not stored locally.',
+        {
+          repositoryId,
+          githubIssueId,
+          githubIssueNumber,
+        },
+      );
+      return;
+    }
+
+    const workspace = await this.workspaceRepository.findById(
+      githubRepository.workspaceId,
+    );
+
+    if (!workspace.capacityPlanningSync) {
+      return;
+    }
+
+    const user = await this.resolveAssigneeUser(assignee);
+
+    if (!user) {
+      console.warn(
+        'Skipping GitHub assignee sync because the assignee is not mapped to a local user.',
+        {
+          repositoryId,
+          githubIssueId,
+          githubIssueNumber,
+          assignee,
+        },
+      );
+      return;
+    }
+
+    const activePlan = await this.resolveCapacityPlan(workspace.id);
+
+    if (!activePlan) {
+      console.warn(
+        'Skipping GitHub assignee sync because the workspace has no capacity plan.',
+        {
+          workspaceId: workspace.id,
+          repositoryId,
+          githubIssueId,
+          githubIssueNumber,
+        },
+      );
+      return;
+    }
+
+    if (action === 'assigned') {
+      await this.createGithubSyncedAssignment({
+        plan: activePlan,
+        issue,
+        userId: user.id,
+        assigneeLogin: assignee.login ?? user.username,
+        repositoryFullName: githubRepository.fullName,
+      });
+      return;
+    }
+
+    await this.removeGithubSyncedAssignment({
+      plan: activePlan,
+      issue,
+      userId: user.id,
+      assigneeLogin: assignee.login ?? user.username,
+      repositoryFullName: githubRepository.fullName,
+    });
+  }
+
+  private async resolveAssigneeUser(assignee: GithubAssigneeIdentity) {
+    if (assignee.id) {
+      const user = await this.userRepository.findOne({
+        where: {githubId: assignee.id},
+      });
+
+      if (user) {
+        return user;
+      }
+    }
+
+    const login = assignee.login?.trim();
+
+    if (!login) {
+      return null;
+    }
+
+    return this.userRepository.findOne({
+      where: {username: login},
+    });
+  }
+
+  private async resolveCapacityPlan(
+    workspaceId: number,
+  ): Promise<CapacityPlan | null> {
+    const now = new Date().toISOString();
+    const activePlan = await this.capacityPlanRepository.findOne({
+      where: {
+        workspaceId,
+        start: {lte: now},
+        end: {gte: now},
+      },
+      order: ['start DESC'],
+    });
+
+    if (activePlan) {
+      return activePlan;
+    }
+
+    return this.capacityPlanRepository.findOne({
+      where: {workspaceId},
+      order: ['start DESC'],
+    });
+  }
+
+  private async createGithubSyncedAssignment({
+    plan,
+    issue,
+    userId,
+    assigneeLogin,
+    repositoryFullName,
+  }: {
+    plan: CapacityPlan;
+    issue: GithubIssue;
+    userId: number;
+    assigneeLogin: string;
+    repositoryFullName: string;
+  }): Promise<void> {
+    const existingAssignment = await this.issueAssignmentRepository.findOne({
+      where: {
+        capacityPlanId: plan.id,
+        issueId: issue.id,
+        userId,
+      },
+    });
+
+    if (existingAssignment) {
+      return;
+    }
+
+    const assignment = await this.issueAssignmentRepository.create({
+      capacityPlanId: plan.id,
+      issueId: issue.id,
+      userId,
+      assignedHours: issue.aiPrediction?.estimatedHours ?? 0,
+    });
+
+    await this.auditEventService.record({
+      actorUserId: userId,
+      workspaceId: plan.workspaceId,
+      action: 'capacity-planning.assignment.imported',
+      resourceType: 'issue-assignment',
+      resourceId: String(assignment.id),
+      source: 'github',
+      payload: {
+        issueId: issue.id,
+        githubIssueNumber: issue.githubIssueNumber,
+        repositoryFullName,
+        assignee: assigneeLogin,
+      },
+    });
+  }
+
+  private async removeGithubSyncedAssignment({
+    plan,
+    issue,
+    userId,
+    assigneeLogin,
+    repositoryFullName,
+  }: {
+    plan: CapacityPlan;
+    issue: GithubIssue;
+    userId: number;
+    assigneeLogin: string;
+    repositoryFullName: string;
+  }): Promise<void> {
+    const assignment = await this.issueAssignmentRepository.findOne({
+      where: {
+        capacityPlanId: plan.id,
+        issueId: issue.id,
+        userId,
+      },
+    });
+
+    if (!assignment?.id) {
+      return;
+    }
+
+    await this.issueAssignmentRepository.deleteById(assignment.id);
+
+    await this.auditEventService.record({
+      actorUserId: userId,
+      workspaceId: plan.workspaceId,
+      action: 'capacity-planning.assignment.removed-from-github',
+      resourceType: 'issue-assignment',
+      resourceId: String(assignment.id),
+      source: 'github',
+      payload: {
+        issueId: issue.id,
+        githubIssueNumber: issue.githubIssueNumber,
+        repositoryFullName,
+        assignee: assigneeLogin,
       },
     });
   }

--- a/api/src/services/github-integration/github-webhook.service.ts
+++ b/api/src/services/github-integration/github-webhook.service.ts
@@ -8,6 +8,7 @@ import {
   GithubReviewerIdentity,
   PullRequestReviewerService,
 } from './pull-request-reviewer.service';
+import {CapacityPlanningSyncService} from '../capacity-planning-sync.service';
 import {IssuePriorityService} from '../issue-priority.service';
 import {QueueService} from '../queue.service';
 
@@ -50,6 +51,10 @@ export type GithubWebhookPayload = {
     state: string;
     pull_request?: unknown;
   };
+  assignee?: {
+    id?: number;
+    login?: string;
+  } | null;
   review?: {
     state?: string;
     user?: GithubReviewerIdentity | null;
@@ -76,6 +81,8 @@ export class GithubWebhookService {
     @service(PullRequestService) private pullRequestService: PullRequestService,
     @service(PullRequestReviewerService)
     private pullRequestReviewerService: PullRequestReviewerService,
+    @service(CapacityPlanningSyncService)
+    private capacityPlanningSyncService: CapacityPlanningSyncService,
     @repository(GithubRepositoryRepository)
     private githubRepositoryRepository: GithubRepositoryRepository,
     @repository(UserRepository)
@@ -125,6 +132,8 @@ export class GithubWebhookService {
         break;
       case 'assigned':
       case 'unassigned':
+        await this.syncIssueAssignee(payload);
+        break;
       case 'labeled':
       case 'unlabeled':
         break;
@@ -365,7 +374,13 @@ export class GithubWebhookService {
   private isAppAuthoredIssueEvent(payload: GithubWebhookPayload): boolean {
     const action = payload.action;
 
-    if (action !== 'opened' && action !== 'edited' && action !== 'reopened') {
+    if (
+      action !== 'opened' &&
+      action !== 'edited' &&
+      action !== 'reopened' &&
+      action !== 'assigned' &&
+      action !== 'unassigned'
+    ) {
       return false;
     }
 
@@ -442,6 +457,28 @@ export class GithubWebhookService {
       pullRequestNumber,
       reviewer,
       status,
+    });
+  }
+
+  private async syncIssueAssignee(
+    payload: GithubWebhookPayload,
+  ): Promise<void> {
+    const repository = await this.resolveRepository(payload);
+
+    if (
+      !repository ||
+      !payload.issue ||
+      (payload.action !== 'assigned' && payload.action !== 'unassigned')
+    ) {
+      return;
+    }
+
+    await this.capacityPlanningSyncService.syncGithubIssueAssigneeChange({
+      action: payload.action,
+      repositoryId: repository.id,
+      githubIssueId: payload.issue.id,
+      githubIssueNumber: payload.issue.number,
+      assignee: payload.assignee,
     });
   }
 


### PR DESCRIPTION
## Summary

This PR syncs GitHub issue assignee changes back into local capacity planning.

When a GitHub issue is assigned or unassigned, the webhook flow now updates the matching local issue assignment in the current workspace capacity plan, as long as capacity planning sync is enabled.

## What changed

- Added handling for GitHub `issues.assigned` and `issues.unassigned` webhook actions.
- Forwarded assignee webhook events from `GithubWebhookService` into `CapacityPlanningSyncService`.
- Added loop prevention so app-authored assignee changes are ignored.
- Added `syncGithubIssueAssigneeChange` to import or remove GitHub assignee changes locally.
- Resolved GitHub issues by repository and GitHub issue ID.
- Resolved GitHub assignees to local users by:
  - GitHub user ID
  - GitHub login / local username fallback
- Resolved the target capacity plan by:
  - active plan for the workspace
  - latest plan fallback when no active plan exists
- Created local issue assignments when GitHub assigns a known user.
- Removed local issue assignments when GitHub unassigns a known user.
- Used AI-estimated issue hours as the default assigned hours when importing a GitHub assignment.
- Skipped sync safely when:
  - capacity planning sync is disabled
  - the issue is not stored locally
  - the GitHub assignee cannot be mapped to a local user
  - the workspace has no capacity plan
  - the assignment already exists
  - the assignment to remove does not exist
- Added audit events for imported and removed GitHub-driven assignments.
- Added unit tests for webhook forwarding, app-authored event skipping, assignment import, assignment removal, disabled sync, unknown users, and missing capacity plans.

## Why

Capacity planning already pushes local assignment changes to GitHub. This PR completes the reverse direction so assignment changes made directly on GitHub can stay reflected in DevTeams planning.

That keeps planning data aligned even when developers manage issue assignees from GitHub instead of the app.

## Testing

Added or updated unit test coverage for:

- importing GitHub assignee changes into the current capacity plan
- removing local assignments after GitHub unassignment
- skipping incoming sync when capacity planning sync is disabled
- skipping incoming sync for unknown GitHub users
- skipping incoming sync when no capacity plan exists
- forwarding assigned/unassigned GitHub issue webhook events
- ignoring app-authored assignee webhook events
- writing audit events for imported/removed assignments

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Unknown
> Reason: AI merge-risk analysis was unavailable.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->