### PR TITLE
Persist issue expertise recommendations

### DIFF
--- a/api/migrations/20260512203000-ai-prediction-expertise-recommendations.js
+++ b/api/migrations/20260512203000-ai-prediction-expertise-recommendations.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260512203000-ai-prediction-expertise-recommendations-up.sql',
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260512203000-ai-prediction-expertise-recommendations-down.sql',
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/sqls/20260512203000-ai-prediction-expertise-recommendations-down.sql
+++ b/api/migrations/sqls/20260512203000-ai-prediction-expertise-recommendations-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system."ai_prediction"
+DROP COLUMN IF EXISTS expertise_recommendations;

--- a/api/migrations/sqls/20260512203000-ai-prediction-expertise-recommendations-up.sql
+++ b/api/migrations/sqls/20260512203000-ai-prediction-expertise-recommendations-up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system."ai_prediction"
+ADD COLUMN IF NOT EXISTS expertise_recommendations jsonb;

--- a/api/src/__tests__/integration/repositories/ai-prediction.repository.test.ts
+++ b/api/src/__tests__/integration/repositories/ai-prediction.repository.test.ts
@@ -87,10 +87,39 @@ describe('AIPredictionRepository (integration)', () => {
         predictionType: 'issue-priority',
         priority: 'High',
         reason: 'Core workflow is blocked.',
+        expertiseRecommendations: [
+          {
+            expertiseId: 3,
+            name: 'Backend',
+            reason: 'The issue affects API behavior.',
+            recommendedUsers: [
+              {
+                userId: 7,
+                username: 'api-owner',
+                fullName: 'API Owner',
+              },
+            ],
+          },
+        ],
       }),
     );
 
     expect(await aiPredictionRepository.count()).toEqual({count: 1});
+    const [prediction] = await aiPredictionRepository.find();
+    expect(prediction.expertiseRecommendations).toEqual([
+      {
+        expertiseId: 3,
+        name: 'Backend',
+        reason: 'The issue affects API behavior.',
+        recommendedUsers: [
+          {
+            userId: 7,
+            username: 'api-owner',
+            fullName: 'API Owner',
+          },
+        ],
+      },
+    ]);
   });
 
   it('registers AI prediction inclusion resolvers for issues and pull requests', async () => {

--- a/api/src/__tests__/unit/controllers/issue.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/issue.controller.test.ts
@@ -131,6 +131,7 @@ describe('GithubIssueController (unit)', () => {
     expect(priorityService.predictIssuePriority).toHaveBeenCalledWith({
       installationId: 11,
       repositoryFullName: 'team/api',
+      workspaceId: 9,
       title: 'Broken sign-in',
       description: 'Users cannot log in',
     });

--- a/api/src/__tests__/unit/models/ai-prediction.model.test.ts
+++ b/api/src/__tests__/unit/models/ai-prediction.model.test.ts
@@ -32,6 +32,20 @@ describe('AI prediction models (unit)', () => {
       reason: 'Critical workflow is blocked.',
       estimatedHours: 8,
       estimationConfidence: 'medium',
+      expertiseRecommendations: [
+        {
+          expertiseId: 4,
+          name: 'Backend',
+          reason: 'API workflow is affected.',
+          recommendedUsers: [
+            {
+              userId: 9,
+              username: 'api-owner',
+              fullName: 'API Owner',
+            },
+          ],
+        },
+      ],
     });
 
     expect(model.sourceType).toBe('github-issue');
@@ -41,6 +55,20 @@ describe('AI prediction models (unit)', () => {
     expect(model.reason).toBe('Critical workflow is blocked.');
     expect(model.estimatedHours).toBe(8);
     expect(model.estimationConfidence).toBe('medium');
+    expect(model.expertiseRecommendations).toEqual([
+      {
+        expertiseId: 4,
+        name: 'Backend',
+        reason: 'API workflow is affected.',
+        recommendedUsers: [
+          {
+            userId: 9,
+            username: 'api-owner',
+            fullName: 'API Owner',
+          },
+        ],
+      },
+    ]);
   });
 
   it('lets GitHub issue and pull request models inherit from AI predictable', () => {

--- a/api/src/__tests__/unit/services/ai-prediction.service.test.ts
+++ b/api/src/__tests__/unit/services/ai-prediction.service.test.ts
@@ -39,6 +39,14 @@ describe('AIPredictionService (unit)', () => {
       estimationConfidence: 'medium',
       findings: [],
       reviewerSuggestions: [],
+      expertiseRecommendations: [
+        {
+          expertiseId: 3,
+          name: 'Backend',
+          reason: 'API behavior is affected.',
+          recommendedUsers: [],
+        },
+      ],
     });
 
     expect(aiPredictionRepository.create).toHaveBeenCalledWith({
@@ -51,6 +59,14 @@ describe('AIPredictionService (unit)', () => {
       estimationConfidence: 'medium',
       findings: [],
       reviewerSuggestions: [],
+      expertiseRecommendations: [
+        {
+          expertiseId: 3,
+          name: 'Backend',
+          reason: 'API behavior is affected.',
+          recommendedUsers: [],
+        },
+      ],
     });
   });
 
@@ -79,6 +95,7 @@ describe('AIPredictionService (unit)', () => {
           reason: 'Owns auth review.',
         },
       ],
+      expertiseRecommendations: undefined,
     });
 
     expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(5, {
@@ -116,6 +133,7 @@ describe('AIPredictionService (unit)', () => {
       estimationConfidence: null,
       findings: [],
       reviewerSuggestions: [],
+      expertiseRecommendations: undefined,
     });
 
     expect(aiPredictionRepository.updateById).toHaveBeenCalledWith(6, {
@@ -197,6 +215,7 @@ describe('AIPredictionService (unit)', () => {
         estimationConfidence: 'high',
         findings: undefined,
         reviewerSuggestions: [],
+        expertiseRecommendations: undefined,
       },
     ]);
   });

--- a/api/src/__tests__/unit/services/github-webhook.service.test.ts
+++ b/api/src/__tests__/unit/services/github-webhook.service.test.ts
@@ -83,6 +83,7 @@ describe('GithubWebhookService (unit)', () => {
       findOne: vi.fn().mockResolvedValue({
         id: 99,
         fullName: 'team/api',
+        workspaceId: 4,
       }),
     };
     userRepository = {
@@ -206,8 +207,16 @@ describe('GithubWebhookService (unit)', () => {
         reason: 'The module is unusable.',
         estimatedHours: 8,
         estimationConfidence: 'medium',
+        expertiseRecommendations: undefined,
       },
     );
+    expect(issuePriorityService.predictIssuePriority).toHaveBeenCalledWith({
+      installationId: 123,
+      repositoryFullName: 'team/api',
+      workspaceId: 4,
+      title: 'Broken',
+      description: 'Updated body',
+    });
     expect(githubService.syncRepositoryLabels).toHaveBeenCalledWith(
       123,
       'team/api',

--- a/api/src/__tests__/unit/services/issue-priority.service.test.ts
+++ b/api/src/__tests__/unit/services/issue-priority.service.test.ts
@@ -11,6 +11,12 @@ describe('IssuePriorityService (unit)', () => {
     listRepositoryDirectory: ReturnType<typeof vi.fn>;
     getRepositoryFileContents: ReturnType<typeof vi.fn>;
   };
+  let expertiseRepository: {
+    find: ReturnType<typeof vi.fn>;
+  };
+  let userExpertiseAssocRepository: {
+    find: ReturnType<typeof vi.fn>;
+  };
   let service: IssuePriorityService;
 
   beforeEach(() => {
@@ -34,11 +40,14 @@ describe('IssuePriorityService (unit)', () => {
       ]),
       getRepositoryFileContents: vi.fn().mockResolvedValue('{}'),
     };
+    expertiseRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+    userExpertiseAssocRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
 
-    service = new IssuePriorityService(
-      ollamaService as never,
-      (async () => githubService as never) as never,
-    );
+    service = createService();
   });
 
   afterEach(() => {
@@ -51,6 +60,17 @@ describe('IssuePriorityService (unit)', () => {
 
     process.env.ISSUE_PRIORITY_CACHE_TTL_MS = originalCacheTtl;
   });
+
+  function createService(
+    githubServiceGetter = (async () => githubService as never) as never,
+  ): IssuePriorityService {
+    return new IssuePriorityService(
+      ollamaService as never,
+      githubServiceGetter,
+      expertiseRepository as never,
+      userExpertiseAssocRepository as never,
+    );
+  }
 
   it('normalizes the model response into a valid prediction', async () => {
     ollamaService.chatJson.mockResolvedValue({
@@ -95,6 +115,87 @@ describe('IssuePriorityService (unit)', () => {
         reason: 'Nope',
       }),
     ).toBeNull();
+  });
+
+  it('attaches workspace expertise recommendations from the catalog', async () => {
+    expertiseRepository.find.mockResolvedValue([
+      {
+        id: 7,
+        name: 'Backend',
+        description: 'LoopBack services and API integrations',
+      },
+    ]);
+    userExpertiseAssocRepository.find.mockResolvedValue([
+      {
+        expertiseId: 7,
+        userId: 13,
+        user: {
+          id: 13,
+          username: 'api-owner',
+          fullName: 'API Owner',
+        },
+      },
+    ]);
+    ollamaService.chatJson.mockResolvedValue({
+      type: 'final',
+      priority: 'High',
+      reason: 'The API module is blocked.',
+      estimated_hours: 6,
+      estimation_confidence: 'high',
+      expertise_recommendations: [
+        {
+          expertise_name: 'Backend',
+          reason: 'The issue affects backend API behavior.',
+        },
+        {
+          expertise_name: 'Unknown catalog entry',
+          reason: 'Should be ignored.',
+        },
+      ],
+    });
+
+    await expect(
+      service.predictIssuePriority({
+        workspaceId: 4,
+        title: 'API cannot save issues',
+        description: 'The issue creation endpoint fails with a 500 error.',
+      }),
+    ).resolves.toEqual({
+      priority: 'High',
+      reason: 'The API module is blocked.',
+      estimatedHours: 6,
+      estimationConfidence: 'high',
+      expertiseRecommendations: [
+        {
+          expertiseId: 7,
+          name: 'Backend',
+          reason: 'The issue affects backend API behavior.',
+          recommendedUsers: [
+            {
+              userId: 13,
+              username: 'api-owner',
+              fullName: 'API Owner',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(expertiseRepository.find).toHaveBeenCalledWith({
+      where: {workspaceId: 4},
+      order: ['name ASC'],
+    });
+    expect(userExpertiseAssocRepository.find).toHaveBeenCalledWith({
+      where: {expertiseId: {inq: [7]}},
+      include: ['user'],
+    });
+    expect(ollamaService.chatJson.mock.calls[0][0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('Workspace expertise catalog'),
+        }),
+      ]),
+    );
   });
 
   it('removes the previous AI note before appending a new one', () => {
@@ -166,10 +267,7 @@ describe('IssuePriorityService (unit)', () => {
 
   it('skips prediction cache when the cache ttl is disabled', async () => {
     process.env.ISSUE_PRIORITY_CACHE_TTL_MS = '0';
-    service = new IssuePriorityService(
-      ollamaService as never,
-      (async () => githubService as never) as never,
-    );
+    service = createService();
     ollamaService.chatJson.mockResolvedValue({
       type: 'final',
       priority: 'Medium',
@@ -193,10 +291,7 @@ describe('IssuePriorityService (unit)', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-30T08:00:00Z'));
     process.env.ISSUE_PRIORITY_CACHE_TTL_MS = '1';
-    service = new IssuePriorityService(
-      ollamaService as never,
-      (async () => githubService as never) as never,
-    );
+    service = createService();
     ollamaService.chatJson
       .mockResolvedValueOnce({
         type: 'final',
@@ -533,8 +628,7 @@ describe('IssuePriorityService (unit)', () => {
   });
 
   it('continues when GitHub service is not bound', async () => {
-    const serviceWithoutGithub = new IssuePriorityService(
-      ollamaService as never,
+    const serviceWithoutGithub = createService(
       (async () => undefined) as never,
     );
     ollamaService.chatJson

--- a/api/src/__tests__/unit/services/issue.service.test.ts
+++ b/api/src/__tests__/unit/services/issue.service.test.ts
@@ -129,6 +129,14 @@ describe('IssueService (unit)', () => {
         reason: 'Critical workflow is blocked.',
         estimatedHours: 8,
         estimationConfidence: 'medium',
+        expertiseRecommendations: [
+          {
+            expertiseId: 4,
+            name: 'Backend',
+            reason: 'API workflow is affected.',
+            recommendedUsers: [],
+          },
+        ],
       },
     );
 
@@ -140,6 +148,14 @@ describe('IssueService (unit)', () => {
       reason: 'Critical workflow is blocked.',
       estimatedHours: 8,
       estimationConfidence: 'medium',
+      expertiseRecommendations: [
+        {
+          expertiseId: 4,
+          name: 'Backend',
+          reason: 'API workflow is affected.',
+          recommendedUsers: [],
+        },
+      ],
     });
   });
 

--- a/api/src/controllers/github/issue.controller.ts
+++ b/api/src/controllers/github/issue.controller.ts
@@ -219,6 +219,7 @@ export class GithubIssueController {
     return this.issuePriorityService.predictIssuePriority({
       installationId: repositoryContext.installationId,
       repositoryFullName: repositoryContext.repository.fullName,
+      workspaceId: repositoryContext.repository.workspaceId,
       title,
       description,
     });

--- a/api/src/models/system/ai-prediction.model.ts
+++ b/api/src/models/system/ai-prediction.model.ts
@@ -26,6 +26,17 @@ export type AIPredictionReviewerSuggestion = {
   reason: string;
 };
 
+export type AIPredictionExpertiseRecommendation = {
+  expertiseId: number;
+  name: string;
+  reason: string;
+  recommendedUsers: Array<{
+    userId: number;
+    username: string;
+    fullName?: string | null;
+  }>;
+};
+
 export const AI_ESTIMATION_CONFIDENCE_VALUES = [
   'low',
   'medium',
@@ -100,6 +111,13 @@ export class AIPrediction extends Entity {
     postgresql: {columnName: 'reviewer_suggestions', dataType: 'jsonb'},
   })
   reviewerSuggestions?: AIPredictionReviewerSuggestion[];
+
+  @property({
+    type: 'array',
+    itemType: 'object',
+    postgresql: {columnName: 'expertise_recommendations', dataType: 'jsonb'},
+  })
+  expertiseRecommendations?: AIPredictionExpertiseRecommendation[];
 
   @property({
     type: 'number',

--- a/api/src/services/ai-prediction.service.ts
+++ b/api/src/services/ai-prediction.service.ts
@@ -4,6 +4,7 @@ import {
   AIPrediction,
   AIEstimationConfidence,
   AIPredictionFinding,
+  AIPredictionExpertiseRecommendation,
   AIPredictionReviewerSuggestion,
   AIPredictionSourceType,
   AIPredictionType,
@@ -18,6 +19,7 @@ export type AIPredictionWrite = {
   reason?: string | null;
   findings?: AIPredictionFinding[] | null;
   reviewerSuggestions?: AIPredictionReviewerSuggestion[] | null;
+  expertiseRecommendations?: AIPredictionExpertiseRecommendation[] | null;
   estimatedHours?: number | null;
   estimationConfidence?: AIEstimationConfidence | null;
 };
@@ -30,6 +32,7 @@ type NormalizedAIPredictionWrite = {
   reason?: string;
   findings?: AIPredictionFinding[];
   reviewerSuggestions?: AIPredictionReviewerSuggestion[];
+  expertiseRecommendations?: AIPredictionExpertiseRecommendation[];
   estimatedHours?: number;
   estimationConfidence?: AIEstimationConfidence;
 };
@@ -66,6 +69,7 @@ export class AIPredictionService {
       reason: prediction.reason,
       findings: prediction.findings,
       reviewerSuggestions: prediction.reviewerSuggestions,
+      expertiseRecommendations: prediction.expertiseRecommendations,
       estimatedHours: prediction.estimatedHours,
       estimationConfidence: prediction.estimationConfidence,
     });
@@ -130,6 +134,7 @@ export class AIPredictionService {
       reason: input.reason?.trim() || undefined,
       findings: input.findings ?? undefined,
       reviewerSuggestions: input.reviewerSuggestions ?? undefined,
+      expertiseRecommendations: input.expertiseRecommendations ?? undefined,
       estimatedHours:
         typeof input.estimatedHours === 'number' &&
         Number.isInteger(input.estimatedHours)
@@ -147,6 +152,7 @@ export class AIPredictionService {
       prediction.reason ||
       prediction.findings?.length ||
       prediction.reviewerSuggestions?.length ||
+      prediction.expertiseRecommendations?.length ||
       typeof prediction.estimatedHours === 'number' ||
       prediction.estimationConfidence,
     );

--- a/api/src/services/github-integration/github-webhook.service.ts
+++ b/api/src/services/github-integration/github-webhook.service.ts
@@ -311,6 +311,7 @@ export class GithubWebhookService {
     const prediction = await this.issuePriorityService.predictIssuePriority({
       installationId: payload.installation?.id ?? null,
       repositoryFullName: repository.fullName,
+      workspaceId: repository.workspaceId,
       title: payload.issue.title,
       description: cleanedDescription,
     });
@@ -333,6 +334,7 @@ export class GithubWebhookService {
         reason: prediction.reason,
         estimatedHours: prediction.estimatedHours,
         estimationConfidence: prediction.estimationConfidence,
+        expertiseRecommendations: prediction.expertiseRecommendations,
       },
     );
 

--- a/api/src/services/github-integration/issue.service.ts
+++ b/api/src/services/github-integration/issue.service.ts
@@ -1,6 +1,6 @@
 import {BindingScope, injectable, service} from '@loopback/core';
 import {Count, DataObject, repository, Where} from '@loopback/repository';
-import {GithubIssue} from '../../models';
+import {AIPredictionExpertiseRecommendation, GithubIssue} from '../../models';
 import {
   GithubIssueRepository,
   GithubRepositoryRepository,
@@ -14,6 +14,7 @@ type IssuePredictionWrite = {
   reason: string;
   estimatedHours?: number | null;
   estimationConfidence?: 'low' | 'medium' | 'high' | null;
+  expertiseRecommendations?: AIPredictionExpertiseRecommendation[] | null;
 };
 
 type GithubIssueWrite = {
@@ -58,15 +59,9 @@ export class IssueService {
       const createdIssue = await this.githubIssueRepository.create(issue);
       await this.recordIssueAudit(createdIssue, 'github.issue.created');
       if (prediction) {
-        await this.aiPredictionService.syncPrediction({
-          sourceType: 'github-issue',
-          sourceId: createdIssue.id,
-          predictionType: 'issue-priority',
-          priority: prediction.priority,
-          reason: prediction.reason,
-          estimatedHours: prediction.estimatedHours,
-          estimationConfidence: prediction.estimationConfidence,
-        });
+        await this.aiPredictionService.syncPrediction(
+          buildAIPredictionWrite(createdIssue.id, prediction),
+        );
       }
       return;
     }
@@ -78,15 +73,9 @@ export class IssueService {
     );
 
     if (prediction) {
-      await this.aiPredictionService.syncPrediction({
-        sourceType: 'github-issue',
-        sourceId: existingIssue.id,
-        predictionType: 'issue-priority',
-        priority: prediction.priority,
-        reason: prediction.reason,
-        estimatedHours: prediction.estimatedHours,
-        estimationConfidence: prediction.estimationConfidence,
-      });
+      await this.aiPredictionService.syncPrediction(
+        buildAIPredictionWrite(existingIssue.id, prediction),
+      );
     }
   }
 
@@ -135,16 +124,9 @@ export class IssueService {
         );
       }
       await this.aiPredictionService.createPredictionsBulk(
-        createdIssues.map((issue, batchIndex) => ({
-          sourceType: 'github-issue',
-          sourceId: issue.id,
-          predictionType: 'issue-priority',
-          priority: batch[batchIndex].prediction.priority,
-          reason: batch[batchIndex].prediction.reason,
-          estimatedHours: batch[batchIndex].prediction.estimatedHours,
-          estimationConfidence:
-            batch[batchIndex].prediction.estimationConfidence,
-        })),
+        createdIssues.map((issue, batchIndex) =>
+          buildAIPredictionWrite(issue.id, batch[batchIndex].prediction),
+        ),
       );
     }
   }
@@ -191,6 +173,24 @@ export class IssueService {
       },
     });
   }
+}
+
+function buildAIPredictionWrite(
+  sourceId: number,
+  prediction: IssuePredictionWrite,
+) {
+  return {
+    sourceType: 'github-issue' as const,
+    sourceId,
+    predictionType: 'issue-priority' as const,
+    priority: prediction.priority,
+    reason: prediction.reason,
+    estimatedHours: prediction.estimatedHours,
+    estimationConfidence: prediction.estimationConfidence,
+    ...(prediction.expertiseRecommendations?.length
+      ? {expertiseRecommendations: prediction.expertiseRecommendations}
+      : {}),
+  };
 }
 
 async function createAllWithoutNewsFeedIfSupported<

--- a/api/src/services/issue-priority.service.ts
+++ b/api/src/services/issue-priority.service.ts
@@ -5,7 +5,16 @@ import {
   injectable,
   service,
 } from '@loopback/core';
-import {AIEstimationConfidence} from '../models';
+import {repository} from '@loopback/repository';
+import {
+  AIEstimationConfidence,
+  AIPredictionExpertiseRecommendation,
+  UserExpertiseAssocWithRelations,
+} from '../models';
+import {
+  ExpertiseRepository,
+  UserExpertiseAssocRepository,
+} from '../repositories';
 import {OllamaService} from './ollama.service';
 import type {GithubService} from './github-integration/github.service';
 
@@ -24,6 +33,7 @@ export type IssuePriorityPrediction = {
   reason: string;
   estimatedHours?: number | null;
   estimationConfidence?: AIEstimationConfidence | null;
+  expertiseRecommendations?: AIPredictionExpertiseRecommendation[];
 };
 
 type PredictionNoteKind = 'priority' | 'risk';
@@ -33,6 +43,7 @@ type PredictIssuePriorityInput = {
   description: string | null;
   installationId?: number | null;
   repositoryFullName?: string | null;
+  workspaceId?: number | null;
 };
 
 type IssuePriorityAiResponse =
@@ -48,12 +59,14 @@ type IssuePriorityAiResponse =
       reason?: string;
       estimated_hours?: number | null;
       estimation_confidence?: string | null;
+      expertise_recommendations?: unknown;
     }
   | {
       priority?: string;
       reason?: string;
       estimated_hours?: number | null;
       estimation_confidence?: string | null;
+      expertise_recommendations?: unknown;
     };
 
 type IssuePriorityToolName =
@@ -65,6 +78,34 @@ type IssuePriorityMessage = {
   role: 'system' | 'user' | 'assistant';
   content: string;
 };
+
+type IssueExpertiseContext = {
+  catalog: Array<{
+    id: number;
+    name: string;
+    description?: string | null;
+    recommendedUsers: Array<{
+      userId: number;
+      username: string;
+      fullName?: string | null;
+    }>;
+  }>;
+  byKey: Map<
+    string,
+    {
+      id: number;
+      name: string;
+      description?: string | null;
+      recommendedUsers: Array<{
+        userId: number;
+        username: string;
+        fullName?: string | null;
+      }>;
+    }
+  >;
+};
+
+type IssueExpertiseCatalogItem = IssueExpertiseContext['catalog'][number];
 
 const AI_PRIORITY_NOTE_START = '<!-- onlab-ai-priority:start -->';
 const AI_PRIORITY_NOTE_END = '<!-- onlab-ai-priority:end -->';
@@ -170,7 +211,13 @@ Return ONLY valid JSON in this exact format:
   "priority": "<Unknown|Low|Medium|High|Very-High>",
   "reason": "<Reason for the priority classification>",
   "estimated_hours": <integer estimate for engineering fix effort>,
-  "estimation_confidence": "<low|medium|high>"
+  "estimation_confidence": "<low|medium|high>",
+  "expertise_recommendations": [
+    {
+      "expertise_name": "<one exact name from the workspace expertise catalog>",
+      "reason": "<why this expertise is relevant>"
+    }
+  ]
 }
 
 Estimate only the engineering implementation effort to fix the issue.
@@ -178,6 +225,9 @@ Use rough whole-hour estimates only.
 Do NOT use decimals.
 Good examples: 1, 2, 4, 8, 16, 24, 40.
 If the issue is too vague to estimate safely, use null or omit the field and set estimation_confidence to "low".
+
+When a workspace expertise catalog is provided, recommend only exact expertise names from that catalog.
+Return an empty expertise_recommendations array if no catalog expertise is clearly relevant.
 
 When tools are available, you may inspect the repository before answering.
 Use tools only when they materially improve the estimate.
@@ -217,6 +267,10 @@ export class IssuePriorityService {
     @service(OllamaService) private ollamaService: OllamaService,
     @inject.getter('services.GithubService', {optional: true})
     private githubServiceGetter: Getter<GithubService | undefined>,
+    @repository(ExpertiseRepository)
+    private expertiseRepository: ExpertiseRepository,
+    @repository(UserExpertiseAssocRepository)
+    private userExpertiseAssocRepository: UserExpertiseAssocRepository,
   ) {}
 
   public async predictIssuePriority({
@@ -224,12 +278,14 @@ export class IssuePriorityService {
     description,
     installationId,
     repositoryFullName,
+    workspaceId,
   }: PredictIssuePriorityInput): Promise<IssuePriorityPrediction> {
     const cleanDescription = this.sanitizeIssueDescription(description);
     const cacheKey = this.buildPredictionCacheKey({
       title,
       description: cleanDescription,
       repositoryFullName,
+      workspaceId,
     });
     const cachedPrediction = this.getCachedPrediction(cacheKey);
 
@@ -248,6 +304,7 @@ export class IssuePriorityService {
       cleanDescription,
       installationId,
       repositoryFullName,
+      workspaceId,
     })
       .then(prediction => {
         this.setCachedPrediction(cacheKey, prediction);
@@ -266,12 +323,15 @@ export class IssuePriorityService {
     cleanDescription,
     installationId,
     repositoryFullName,
+    workspaceId,
   }: {
     title: string;
     cleanDescription: string;
     installationId?: number | null;
     repositoryFullName?: string | null;
+    workspaceId?: number | null;
   }): Promise<IssuePriorityPrediction> {
+    const expertiseContext = await this.buildExpertiseContext(workspaceId);
     const messages: IssuePriorityMessage[] = [
       {
         role: 'system',
@@ -283,6 +343,7 @@ export class IssuePriorityService {
           repositoryFullName ? `Repository: ${repositoryFullName}` : null,
           `Issue title: ${title}`,
           `Issue description:\n${cleanDescription || '(empty)'}`,
+          this.buildExpertisePromptContext(expertiseContext),
         ]
           .filter(Boolean)
           .join('\n'),
@@ -305,7 +366,7 @@ export class IssuePriorityService {
           });
 
         if (isFinalResponse(response)) {
-          return this.normalizePrediction(response);
+          return this.normalizePrediction(response, expertiseContext);
         }
 
         if (!isToolCallResponse(response)) {
@@ -374,13 +435,16 @@ export class IssuePriorityService {
     title,
     description,
     repositoryFullName,
+    workspaceId,
   }: {
     title: string;
     description: string;
     repositoryFullName?: string | null;
+    workspaceId?: number | null;
   }): string {
     return JSON.stringify({
       repositoryFullName: repositoryFullName ?? null,
+      workspaceId: workspaceId ?? null,
       title: title.trim(),
       description: description.trim(),
     });
@@ -450,6 +514,9 @@ export class IssuePriorityService {
       estimationConfidence: normalizeEstimationConfidence(
         prediction.estimationConfidence,
       ),
+      expertiseRecommendations: normalizeExistingExpertiseRecommendations(
+        prediction.expertiseRecommendations,
+      ),
     };
   }
 
@@ -484,6 +551,9 @@ export class IssuePriorityService {
       prediction.estimatedHours
         ? `> Estimated effort: ${prediction.estimatedHours}h (${prediction.estimationConfidence ?? 'unknown'} confidence)`
         : null,
+      ...formatExpertiseRecommendationNoteLines(
+        prediction.expertiseRecommendations,
+      ),
       '> Written by `DevTeams`',
       AI_PRIORITY_NOTE_END,
     ].join('\n');
@@ -509,12 +579,16 @@ export class IssuePriorityService {
     return `Risk: ${priority}`;
   }
 
-  private normalizePrediction(response: {
-    priority?: string;
-    reason?: string;
-    estimated_hours?: number | null;
-    estimation_confidence?: string | null;
-  }): IssuePriorityPrediction {
+  private normalizePrediction(
+    response: {
+      priority?: string;
+      reason?: string;
+      estimated_hours?: number | null;
+      estimation_confidence?: string | null;
+      expertise_recommendations?: unknown;
+    },
+    expertiseContext?: IssueExpertiseContext | null,
+  ): IssuePriorityPrediction {
     const priority = normalizeIssuePriority(response.priority);
 
     return {
@@ -523,6 +597,10 @@ export class IssuePriorityService {
       estimatedHours: normalizeEstimatedHours(response.estimated_hours),
       estimationConfidence: normalizeEstimationConfidence(
         response.estimation_confidence,
+      ),
+      expertiseRecommendations: normalizeAiExpertiseRecommendations(
+        response.expertise_recommendations,
+        expertiseContext,
       ),
     };
   }
@@ -542,6 +620,74 @@ export class IssuePriorityService {
       estimatedHours: null,
       estimationConfidence: 'low',
     };
+  }
+
+  private async buildExpertiseContext(
+    workspaceId?: number | null,
+  ): Promise<IssueExpertiseContext | null> {
+    if (!workspaceId) {
+      return null;
+    }
+
+    const expertises = await this.expertiseRepository.find({
+      where: {workspaceId},
+      order: ['name ASC'],
+    });
+
+    const expertiseIds = expertises
+      .map(expertise => expertise.id)
+      .filter((id): id is number => typeof id === 'number');
+
+    if (!expertiseIds.length) {
+      return null;
+    }
+
+    const expertiseUsers = await this.userExpertiseAssocRepository.find({
+      where: {expertiseId: {inq: expertiseIds}},
+      include: ['user'],
+    });
+    const usersByExpertiseId = groupUsersByExpertiseId(expertiseUsers);
+    const catalog = expertises.map(expertise => ({
+      id: expertise.id,
+      name: expertise.name,
+      description: expertise.description ?? null,
+      recommendedUsers: usersByExpertiseId.get(expertise.id) ?? [],
+    }));
+
+    return {
+      catalog,
+      byKey: new Map(
+        catalog.map(item => [normalizeExpertiseKey(item.name), item]),
+      ),
+    };
+  }
+
+  private buildExpertisePromptContext(
+    expertiseContext: IssueExpertiseContext | null,
+  ): string | null {
+    if (!expertiseContext?.catalog.length) {
+      return null;
+    }
+
+    return [
+      'Workspace expertise catalog:',
+      ...expertiseContext.catalog.map(item =>
+        [
+          `- ${item.name}`,
+          item.description?.trim()
+            ? `description=${item.description.trim()}`
+            : null,
+          item.recommendedUsers.length
+            ? `people=${item.recommendedUsers
+                .map(user => user.fullName || user.username)
+                .join(', ')}`
+            : 'people=none',
+        ]
+          .filter(Boolean)
+          .join(' | '),
+      ),
+      'Use exact expertise names from this catalog in expertise_recommendations.',
+    ].join('\n');
   }
 
   private async buildInitialEvidenceMessage(context: {
@@ -799,6 +945,183 @@ function normalizeEstimationConfidence(
     default:
       return null;
   }
+}
+
+function normalizeExistingExpertiseRecommendations(
+  value: IssuePriorityPrediction['expertiseRecommendations'],
+): AIPredictionExpertiseRecommendation[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const recommendations = value
+    .map(recommendation => {
+      const expertiseId = recommendation.expertiseId;
+      const name = recommendation.name?.trim();
+
+      if (typeof expertiseId !== 'number' || !Number.isFinite(expertiseId)) {
+        return null;
+      }
+
+      if (!name) {
+        return null;
+      }
+
+      return {
+        expertiseId,
+        name,
+        reason:
+          recommendation.reason?.trim() ||
+          'Relevant workspace expertise for this issue.',
+        recommendedUsers: normalizeRecommendedUsers(
+          recommendation.recommendedUsers,
+        ),
+      };
+    })
+    .filter(
+      (recommendation): recommendation is AIPredictionExpertiseRecommendation =>
+        recommendation !== null,
+    );
+
+  return recommendations.length ? recommendations : undefined;
+}
+
+function normalizeAiExpertiseRecommendations(
+  value: unknown,
+  expertiseContext?: IssueExpertiseContext | null,
+): AIPredictionExpertiseRecommendation[] | undefined {
+  if (!Array.isArray(value) || !expertiseContext) {
+    return undefined;
+  }
+
+  const seenExpertiseIds = new Set<number>();
+  const recommendations: AIPredictionExpertiseRecommendation[] = [];
+
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const rawName = item.expertise_name ?? item.name;
+
+    if (typeof rawName !== 'string') {
+      continue;
+    }
+
+    const expertise = expertiseContext.byKey.get(
+      normalizeExpertiseKey(rawName),
+    );
+
+    if (!expertise || seenExpertiseIds.has(expertise.id)) {
+      continue;
+    }
+
+    seenExpertiseIds.add(expertise.id);
+    recommendations.push({
+      expertiseId: expertise.id,
+      name: expertise.name,
+      reason:
+        typeof item.reason === 'string' && item.reason.trim()
+          ? item.reason.trim()
+          : 'Relevant workspace expertise for this issue.',
+      recommendedUsers: expertise.recommendedUsers,
+    });
+  }
+
+  return recommendations.length ? recommendations : undefined;
+}
+
+function formatExpertiseRecommendationNoteLines(
+  recommendations: AIPredictionExpertiseRecommendation[] | undefined,
+): string[] {
+  if (!recommendations?.length) {
+    return [];
+  }
+
+  const expertiseSummary = recommendations
+    .map(recommendation => `${recommendation.name} (${recommendation.reason})`)
+    .join('; ');
+  const recommendedUsers = [
+    ...new Set(
+      recommendations.flatMap(recommendation =>
+        recommendation.recommendedUsers.map(
+          user => user.fullName || user.username,
+        ),
+      ),
+    ),
+  ];
+
+  return [
+    `> Relevant expertise: ${expertiseSummary}`,
+    recommendedUsers.length
+      ? `> Recommended people: ${recommendedUsers.join(', ')}`
+      : null,
+  ].filter((line): line is string => Boolean(line));
+}
+
+function groupUsersByExpertiseId(
+  associations: UserExpertiseAssocWithRelations[],
+): Map<number, IssueExpertiseCatalogItem['recommendedUsers']> {
+  const usersByExpertiseId = new Map<
+    number,
+    IssueExpertiseCatalogItem['recommendedUsers']
+  >();
+
+  for (const association of associations) {
+    const user = association.user;
+
+    if (!user?.id || !user.username?.trim()) {
+      continue;
+    }
+
+    const users = usersByExpertiseId.get(association.expertiseId) ?? [];
+    users.push({
+      userId: user.id,
+      username: user.username,
+      fullName: user.fullName ?? null,
+    });
+    usersByExpertiseId.set(association.expertiseId, users);
+  }
+
+  return usersByExpertiseId;
+}
+
+function normalizeRecommendedUsers(
+  value: AIPredictionExpertiseRecommendation['recommendedUsers'],
+): AIPredictionExpertiseRecommendation['recommendedUsers'] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const users: AIPredictionExpertiseRecommendation['recommendedUsers'] = [];
+
+  for (const user of value) {
+    if (typeof user.userId !== 'number' || !Number.isFinite(user.userId)) {
+      continue;
+    }
+
+    const username = user.username?.trim();
+
+    if (!username) {
+      continue;
+    }
+
+    users.push({
+      userId: user.userId,
+      username,
+      fullName: user.fullName?.trim() || null,
+    });
+  }
+
+  return users;
+}
+
+function normalizeExpertiseKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function clampNumber(

--- a/api/src/workers/github.worker.ts
+++ b/api/src/workers/github.worker.ts
@@ -300,6 +300,7 @@ async function processCreateIssueJob(
     (await issuePriorityService.predictIssuePriority({
       installationId,
       repositoryFullName: repository.fullName,
+      workspaceId: repository.workspaceId,
       title: job.data.title,
       description: job.data.description,
     }));
@@ -545,6 +546,7 @@ async function syncRepositoryIssues(
       const prediction = await issuePriorityService.predictIssuePriority({
         installationId,
         repositoryFullName: repository.fullName,
+        workspaceId: repository.workspaceId,
         title: githubIssue.title,
         description,
       });

--- a/client/app/components/routes/workspaces/edit/issues/edit.gts
+++ b/client/app/components/routes/workspaces/edit/issues/edit.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { LinkTo } from '@ember/routing';
 import { modifier } from 'ember-modifier';
+import { or } from 'ember-truth-helpers';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import type { WorkspacesEditIssuesEditRouteModel } from 'client/routes/workspaces/edit/issues/edit';
@@ -113,6 +114,10 @@ export default class RoutesWorkspacesEditIssuesEdit extends Component<RoutesWork
     return `${this.issue.estimatedHours}h${confidenceLabel}`;
   }
 
+  get expertiseRecommendations() {
+    return this.issue.expertiseRecommendations ?? [];
+  }
+
   get closeRoute(): string {
     return this.args.closeRoute ?? 'workspaces.edit.issues';
   }
@@ -187,6 +192,29 @@ export default class RoutesWorkspacesEditIssuesEdit extends Component<RoutesWork
             <p class="issue-edit-analysis__content margin-zero">
               {{this.priorityReason}}
             </p>
+            {{#if this.expertiseRecommendations.length}}
+              <div class="layout-vertical --gap-sm">
+                <span class="issue-edit-section__label">
+                  Relevant expertise
+                </span>
+                {{#each this.expertiseRecommendations as |expertise|}}
+                  <div class="layout-vertical --gap-xs">
+                    <strong>{{expertise.name}}</strong>
+                    <p class="issue-edit-analysis__content margin-zero">
+                      {{expertise.reason}}
+                    </p>
+                    {{#if expertise.recommendedUsers.length}}
+                      <span class="font-size-text-sm">
+                        Suggested people:
+                        {{#each expertise.recommendedUsers as |user index|}}
+                          {{if index ", "}}{{or user.fullName user.username}}
+                        {{/each}}
+                      </span>
+                    {{/if}}
+                  </div>
+                {{/each}}
+              </div>
+            {{/if}}
           </:default>
         </UiContainer>
 

--- a/client/app/components/routes/workspaces/edit/issues/new.gts
+++ b/client/app/components/routes/workspaces/edit/issues/new.gts
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { LinkTo } from '@ember/routing';
 import { on } from '@ember/modifier';
+import { or } from 'ember-truth-helpers';
 import type GithubRepositoryModel from 'client/models/github-repository';
 import type { WorkspacesEditIssuesNewRouteModel } from 'client/routes/workspaces/edit/issues/new';
 import UiButton from 'client/components/ui/button';
@@ -20,6 +21,18 @@ type AnalyzeIssueResponse = {
   reason: string;
   estimatedHours?: number | null;
   estimationConfidence?: 'low' | 'medium' | 'high' | null;
+  expertiseRecommendations?: ExpertiseRecommendation[] | null;
+};
+
+type ExpertiseRecommendation = {
+  expertiseId: number;
+  name: string;
+  reason: string;
+  recommendedUsers: Array<{
+    userId: number;
+    username: string;
+    fullName?: string | null;
+  }>;
 };
 
 type CreateIssueResponse = {
@@ -141,6 +154,10 @@ export default class RoutesWorkspacesEditIssuesNew extends Component<RoutesWorks
       : '';
 
     return `${this.analysisResult.estimatedHours}h${confidenceLabel}`;
+  }
+
+  get expertiseRecommendations(): ExpertiseRecommendation[] {
+    return this.analysisResult?.expertiseRecommendations ?? [];
   }
 
   analyzeIssueTask = task(async () => {
@@ -357,6 +374,32 @@ export default class RoutesWorkspacesEditIssuesNew extends Component<RoutesWorks
                     Estimated effort:
                     {{this.estimatedHoursLabel}}
                   </p>
+                {{/if}}
+                {{#if this.expertiseRecommendations.length}}
+                  <div class="layout-vertical --gap-sm">
+                    <span class="issue-edit-section__label">
+                      Relevant expertise
+                    </span>
+                    {{#each this.expertiseRecommendations as |expertise|}}
+                      <div class="layout-vertical --gap-xs">
+                        <strong>{{expertise.name}}</strong>
+                        <p class="issue-edit-analysis__content margin-zero">
+                          {{expertise.reason}}
+                        </p>
+                        {{#if expertise.recommendedUsers.length}}
+                          <span class="font-size-text-sm">
+                            Suggested people:
+                            {{#each expertise.recommendedUsers as |user index|}}
+                              {{if index ", "}}{{or
+                                user.fullName
+                                user.username
+                              }}
+                            {{/each}}
+                          </span>
+                        {{/if}}
+                      </div>
+                    {{/each}}
+                  </div>
                 {{/if}}
               </:default>
             </UiContainer>

--- a/client/app/models/ai-prediction.ts
+++ b/client/app/models/ai-prediction.ts
@@ -17,6 +17,16 @@ export default class AIPredictionModel extends Model {
     username: string;
     reason: string;
   }> | null;
+  @attr() declare expertiseRecommendations: Array<{
+    expertiseId: number;
+    name: string;
+    reason: string;
+    recommendedUsers: Array<{
+      userId: number;
+      username: string;
+      fullName?: string | null;
+    }>;
+  }> | null;
   @attr('number') declare estimatedHours: number | null;
   @attr('string')
   declare estimationConfidence: 'low' | 'medium' | 'high' | null;

--- a/client/app/models/github-issue.ts
+++ b/client/app/models/github-issue.ts
@@ -38,4 +38,10 @@ export default class GithubIssueModel extends Model {
   get estimationConfidence(): 'low' | 'medium' | 'high' | null {
     return this.aiPrediction?.estimationConfidence ?? null;
   }
+
+  get expertiseRecommendations():
+    | AIPredictionModel['expertiseRecommendations']
+    | null {
+    return this.aiPrediction?.expertiseRecommendations ?? null;
+  }
 }


### PR DESCRIPTION
## Summary

This PR persists and surfaces issue expertise recommendations.

Issue priority prediction now uses the workspace expertise catalog to recommend relevant expertise areas and linked users. Those recommendations are stored with the AI prediction and displayed in the issue creation/detail UI.

## What changed

- Added an `expertise_recommendations` JSONB column to `system.ai_prediction`.
- Extended the `AIPrediction` model with persisted expertise recommendations.
- Extended `AIPredictionService` create/update/sync logic to store expertise recommendations.
- Updated issue priority prediction to include workspace expertise context in the AI prompt.
- Added support for AI output containing expertise recommendations.
- Normalized expertise recommendations against the workspace expertise catalog.
- Ignored unknown expertise names returned by the AI.
- Included recommended users for each matched expertise based on user expertise assignments.
- Passed `workspaceId` into issue priority prediction from:
  - issue analysis endpoint
  - GitHub issue webhook prediction flow
- Persisted expertise recommendations when syncing GitHub issue predictions.
- Included expertise recommendations in bulk issue prediction persistence.
- Updated client models for `AIPrediction` and `GithubIssue`.
- Updated issue creation and issue detail UI to show recommended expertise/users.
- Added tests for model persistence, repository integration, prediction normalization, AI prompt context, issue service persistence, webhook prediction flow, and client-facing prediction data.

## Why

Issue priority predictions already identify severity, reasoning, estimates, and confidence. This PR makes predictions more actionable by connecting issues to the workspace’s expertise catalog and the people associated with those expertise areas.

That helps teams quickly understand who should look at an issue and why.

## Testing

Added or updated test coverage for:

- storing `expertiseRecommendations` on AI predictions
- reading persisted expertise recommendations from the repository
- syncing expertise recommendations through `AIPredictionService`
- including workspace expertise catalog context in issue priority prompts
- normalizing AI expertise recommendations against known catalog entries
- ignoring unknown expertise names returned by AI
- attaching recommended users to matched expertise areas
- passing `workspaceId` through issue analysis and webhook flows
- persisting expertise recommendations during issue upsert and bulk prediction writes
- rendering expertise recommendations in issue creation/detail client flows

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Unknown
> Reason: AI merge-risk analysis was unavailable.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->