### PR TITLE
Normalize role vs expertise

### DIFF
--- a/api/migrations/20260513100000-unique-workspace-expertise-name.js
+++ b/api/migrations/20260513100000-unique-workspace-expertise-name.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options) {
+  Promise = options.Promise;
+};
+
+function runSqlFile(db, fileName) {
+  var filePath = path.join(__dirname, 'sqls', fileName);
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+}
+
+exports.up = function(db) {
+  return runSqlFile(db, '20260513100000-unique-workspace-expertise-name-up.sql');
+};
+
+exports.down = function(db) {
+  return runSqlFile(db, '20260513100000-unique-workspace-expertise-name-down.sql');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/sqls/20260513100000-unique-workspace-expertise-name-down.sql
+++ b/api/migrations/sqls/20260513100000-unique-workspace-expertise-name-down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "system"."expertise_unique_workspace_lower_name";

--- a/api/migrations/sqls/20260513100000-unique-workspace-expertise-name-up.sql
+++ b/api/migrations/sqls/20260513100000-unique-workspace-expertise-name-up.sql
@@ -1,0 +1,57 @@
+WITH duplicate_expertise AS (
+  SELECT
+    id,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY workspace_id, LOWER(TRIM(name))
+      ORDER BY id
+    ) AS keep_id
+  FROM "system"."expertise"
+),
+duplicate_user_expertise AS (
+  SELECT assoc.id
+  FROM "system"."user_expertise_assoc" assoc
+  JOIN duplicate_expertise duplicate
+    ON duplicate.id = assoc.expertise_id
+  WHERE duplicate.id <> duplicate.keep_id
+    AND EXISTS (
+      SELECT 1
+      FROM "system"."user_expertise_assoc" existing
+      WHERE existing.user_id = assoc.user_id
+        AND existing.expertise_id = duplicate.keep_id
+    )
+)
+DELETE FROM "system"."user_expertise_assoc" assoc
+USING duplicate_user_expertise duplicate_assoc
+WHERE assoc.id = duplicate_assoc.id;
+
+WITH duplicate_expertise AS (
+  SELECT
+    id,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY workspace_id, LOWER(TRIM(name))
+      ORDER BY id
+    ) AS keep_id
+  FROM "system"."expertise"
+)
+UPDATE "system"."user_expertise_assoc" assoc
+SET expertise_id = duplicate.keep_id
+FROM duplicate_expertise duplicate
+WHERE assoc.expertise_id = duplicate.id
+  AND duplicate.id <> duplicate.keep_id;
+
+WITH duplicate_expertise AS (
+  SELECT
+    id,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY workspace_id, LOWER(TRIM(name))
+      ORDER BY id
+    ) AS keep_id
+  FROM "system"."expertise"
+)
+DELETE FROM "system"."expertise" expertise
+USING duplicate_expertise duplicate
+WHERE expertise.id = duplicate.id
+  AND duplicate.id <> duplicate.keep_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS expertise_unique_workspace_lower_name
+  ON "system"."expertise" (workspace_id, LOWER(TRIM(name)));

--- a/api/src/__tests__/unit/controllers/rbac-managed-controllers.test.ts
+++ b/api/src/__tests__/unit/controllers/rbac-managed-controllers.test.ts
@@ -41,10 +41,16 @@ describe('RBAC-managed explicit controllers (unit)', () => {
       replaceById: vi.fn().mockResolvedValue(undefined),
       deleteById: vi.fn().mockResolvedValue(undefined),
     };
+    const expertiseCatalogService = {
+      createExpertise: vi.fn().mockResolvedValue(expertise),
+      updateExpertise: vi.fn().mockResolvedValue(undefined),
+      replaceExpertise: vi.fn().mockResolvedValue(undefined),
+    };
     const authorization = createAuthorization();
     const controller = new ExpertiseController(
       repository as never,
       authorization as never,
+      expertiseCatalogService as never,
     );
 
     await expect(
@@ -88,6 +94,19 @@ describe('RBAC-managed explicit controllers (unit)', () => {
     expect(repository.count).toHaveBeenCalledWith({
       and: [{name: 'Frontend'}, {workspaceId: {inq: [3]}}],
     });
+    expect(expertiseCatalogService.createExpertise).toHaveBeenCalledWith({
+      workspaceId: 3,
+      name: 'Frontend',
+      description: 'UI work',
+    });
+    expect(expertiseCatalogService.updateExpertise).toHaveBeenCalledWith(12, {
+      description: 'Design systems',
+    });
+    expect(expertiseCatalogService.replaceExpertise).toHaveBeenCalledWith(12, {
+      workspaceId: 3,
+      name: 'Frontend',
+      description: 'Design systems',
+    });
     expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
     expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
       3,
@@ -113,6 +132,11 @@ describe('RBAC-managed explicit controllers (unit)', () => {
       replaceById: vi.fn().mockResolvedValue(undefined),
       deleteById: vi.fn().mockResolvedValue(undefined),
     };
+    const expertiseCatalogService = {
+      assignExpertise: vi.fn().mockResolvedValue(assoc),
+      updateAssignment: vi.fn().mockResolvedValue(undefined),
+      removeAssignment: vi.fn().mockResolvedValue(undefined),
+    };
     const expertiseRepository = {
       find: vi
         .fn()
@@ -126,6 +150,7 @@ describe('RBAC-managed explicit controllers (unit)', () => {
       assocRepository as never,
       expertiseRepository as never,
       authorization as never,
+      expertiseCatalogService as never,
     );
 
     await expect(
@@ -158,6 +183,18 @@ describe('RBAC-managed explicit controllers (unit)', () => {
         and: [{userId: 9}, {expertiseId: {inq: [12]}}],
       },
     });
+    expect(expertiseCatalogService.assignExpertise).toHaveBeenCalledWith({
+      userId: 9,
+      expertiseId: 12,
+    });
+    expect(expertiseCatalogService.updateAssignment).toHaveBeenCalledWith(14, {
+      userId: 10,
+    });
+    expect(expertiseCatalogService.updateAssignment).toHaveBeenCalledWith(14, {
+      userId: 10,
+      expertiseId: 12,
+    });
+    expect(expertiseCatalogService.removeAssignment).toHaveBeenCalledWith(14);
     expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 7);
     expect(authorization.assertWorkspaceAdminOrOwner).toHaveBeenCalledWith(
       3,

--- a/api/src/__tests__/unit/services/expertise-catalog.service.test.ts
+++ b/api/src/__tests__/unit/services/expertise-catalog.service.test.ts
@@ -1,0 +1,158 @@
+import {HttpErrors} from '@loopback/rest';
+import {describe, expect, it, vi} from 'vitest';
+
+import {ExpertiseCatalogService} from '../../../services/expertise-catalog.service';
+import {Expertise, UserExpertiseAssoc} from '../../../models';
+
+const createService = ({
+  expertises = [],
+  assignment,
+}: {
+  expertises?: Expertise[];
+  assignment?: UserExpertiseAssoc | null;
+} = {}) => {
+  const expertiseRepository = {
+    find: vi.fn().mockResolvedValue(expertises),
+    findById: vi
+      .fn()
+      .mockImplementation((id: number) =>
+        Promise.resolve(
+          expertises.find(expertise => expertise.id === id) ??
+            new Expertise({id, workspaceId: 3, name: 'Backend'}),
+        ),
+      ),
+    create: vi
+      .fn()
+      .mockImplementation((data: Partial<Expertise>) =>
+        Promise.resolve(new Expertise({id: 99, ...data})),
+      ),
+    updateById: vi.fn().mockResolvedValue(undefined),
+    replaceById: vi.fn().mockResolvedValue(undefined),
+  };
+  const userExpertiseAssocRepository = {
+    findById: vi
+      .fn()
+      .mockResolvedValue(
+        new UserExpertiseAssoc({id: 7, userId: 4, expertiseId: 1}),
+      ),
+    findOne: vi.fn().mockResolvedValue(assignment ?? null),
+    create: vi
+      .fn()
+      .mockImplementation((data: Partial<UserExpertiseAssoc>) =>
+        Promise.resolve(new UserExpertiseAssoc({id: 10, ...data})),
+      ),
+    updateById: vi.fn().mockResolvedValue(undefined),
+    deleteById: vi.fn().mockResolvedValue(undefined),
+  };
+  const workspaceAuthorizationService = {
+    assertWorkspaceMember: vi.fn().mockResolvedValue('MEMBER'),
+  };
+
+  return {
+    service: new ExpertiseCatalogService(
+      expertiseRepository as never,
+      userExpertiseAssocRepository as never,
+      workspaceAuthorizationService as never,
+    ),
+    expertiseRepository,
+    userExpertiseAssocRepository,
+    workspaceAuthorizationService,
+  };
+};
+
+describe('ExpertiseCatalogService (unit)', () => {
+  it('normalizes and creates unique workspace expertise', async () => {
+    const {service, expertiseRepository} = createService();
+
+    const expertise = await service.createExpertise({
+      workspaceId: 3,
+      name: '  Backend   Development ',
+      description: '  API and data work  ',
+    });
+
+    expect(expertise.name).toBe('Backend Development');
+    expect(expertise.description).toBe('API and data work');
+    expect(expertiseRepository.create).toHaveBeenCalledWith({
+      workspaceId: 3,
+      name: 'Backend Development',
+      description: 'API and data work',
+    });
+  });
+
+  it('rejects duplicate expertise names case-insensitively in a workspace', async () => {
+    const {service} = createService({
+      expertises: [
+        new Expertise({id: 1, workspaceId: 3, name: 'Frontend Development'}),
+      ],
+    });
+
+    await expect(
+      service.createExpertise({
+        workspaceId: 3,
+        name: ' frontend   development ',
+      }),
+    ).rejects.toBeInstanceOf(HttpErrors.Conflict);
+  });
+
+  it('keeps expertise in its original workspace when updating', async () => {
+    const {service, expertiseRepository} = createService({
+      expertises: [new Expertise({id: 1, workspaceId: 3, name: 'QA'})],
+    });
+
+    await service.updateExpertise(1, {
+      workspaceId: 44,
+      name: ' Quality Assurance ',
+      description: '',
+    });
+
+    expect(expertiseRepository.updateById).toHaveBeenCalledWith(1, {
+      workspaceId: 3,
+      name: 'Quality Assurance',
+      description: undefined,
+    });
+  });
+
+  it('assigns existing expertise once and returns an existing assignment', async () => {
+    const existingAssignment = new UserExpertiseAssoc({
+      id: 6,
+      userId: 4,
+      expertiseId: 1,
+    });
+    const {
+      service,
+      userExpertiseAssocRepository,
+      workspaceAuthorizationService,
+    } = createService({
+      expertises: [new Expertise({id: 1, workspaceId: 3, name: 'Backend'})],
+      assignment: existingAssignment,
+    });
+
+    await expect(
+      service.assignExpertise({userId: 4, expertiseId: 1}),
+    ).resolves.toBe(existingAssignment);
+
+    expect(
+      workspaceAuthorizationService.assertWorkspaceMember,
+    ).toHaveBeenCalledWith(3, 4);
+    expect(userExpertiseAssocRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects assignment updates that would duplicate an existing user expertise', async () => {
+    const {service} = createService({
+      expertises: [new Expertise({id: 2, workspaceId: 3, name: 'Frontend'})],
+      assignment: new UserExpertiseAssoc({id: 8, userId: 4, expertiseId: 2}),
+    });
+
+    await expect(
+      service.updateAssignment(7, {userId: 4, expertiseId: 2}),
+    ).rejects.toBeInstanceOf(HttpErrors.Conflict);
+  });
+
+  it('removes expertise assignments by id', async () => {
+    const {service, userExpertiseAssocRepository} = createService();
+
+    await service.removeAssignment(7);
+
+    expect(userExpertiseAssocRepository.deleteById).toHaveBeenCalledWith(7);
+  });
+});

--- a/api/src/controllers/system/expertise.controller.ts
+++ b/api/src/controllers/system/expertise.controller.ts
@@ -6,7 +6,10 @@ import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {Expertise, ExpertiseRelations} from '../../models';
 import {ExpertiseRepository} from '../../repositories';
-import {WorkspaceAuthorizationService} from '../../services';
+import {
+  ExpertiseCatalogService,
+  WorkspaceAuthorizationService,
+} from '../../services';
 
 @authenticate('jwt-header')
 export class ExpertiseController {
@@ -15,6 +18,8 @@ export class ExpertiseController {
     private expertiseRepository: ExpertiseRepository,
     @service(WorkspaceAuthorizationService)
     private workspaceAuthorizationService: WorkspaceAuthorizationService,
+    @service(ExpertiseCatalogService)
+    private expertiseCatalogService: ExpertiseCatalogService,
   ) {}
 
   @get('/expertises')
@@ -88,7 +93,7 @@ export class ExpertiseController {
   ): Promise<Expertise> {
     await this.assertCanManageExpertise(userProfile, data.workspaceId);
 
-    return this.expertiseRepository.create(data);
+    return this.expertiseCatalogService.createExpertise(data);
   }
 
   @patch('/expertises/{id}')
@@ -111,7 +116,7 @@ export class ExpertiseController {
     const expertise = await this.expertiseRepository.findById(id);
     await this.assertCanManageExpertise(userProfile, expertise.workspaceId);
 
-    return this.expertiseRepository.updateById(id, data);
+    return this.expertiseCatalogService.updateExpertise(id, data);
   }
 
   @put('/expertises/{id}')
@@ -134,7 +139,7 @@ export class ExpertiseController {
     const expertise = await this.expertiseRepository.findById(id);
     await this.assertCanManageExpertise(userProfile, expertise.workspaceId);
 
-    return this.expertiseRepository.replaceById(id, data);
+    return this.expertiseCatalogService.replaceExpertise(id, data);
   }
 
   @del('/expertises/{id}')

--- a/api/src/controllers/system/user-expertise-assoc.controller.ts
+++ b/api/src/controllers/system/user-expertise-assoc.controller.ts
@@ -9,7 +9,10 @@ import {
 } from '../../repositories';
 import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
-import {WorkspaceAuthorizationService} from '../../services';
+import {
+  ExpertiseCatalogService,
+  WorkspaceAuthorizationService,
+} from '../../services';
 
 @authenticate('jwt-header')
 export class UserExpertiseAssocController {
@@ -20,6 +23,8 @@ export class UserExpertiseAssocController {
     private expertiseRepository: ExpertiseRepository,
     @inject('services.WorkspaceAuthorizationService')
     private workspaceAuthorizationService: WorkspaceAuthorizationService,
+    @inject('services.ExpertiseCatalogService')
+    private expertiseCatalogService: ExpertiseCatalogService,
   ) {}
 
   @get('/userExpertiseAssocs')
@@ -95,7 +100,7 @@ export class UserExpertiseAssocController {
   ): Promise<UserExpertiseAssoc> {
     await this.assertCanManageAssoc(userProfile, Number(data.expertiseId));
 
-    return this.userExpertiseAssocRepository.create(data);
+    return this.expertiseCatalogService.assignExpertise(data);
   }
 
   @patch('/userExpertiseAssocs/{id}')
@@ -117,8 +122,11 @@ export class UserExpertiseAssocController {
   ): Promise<void> {
     const assoc = await this.userExpertiseAssocRepository.findById(id);
     await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
+    if (data.expertiseId !== undefined) {
+      await this.assertCanManageAssoc(userProfile, Number(data.expertiseId));
+    }
 
-    return this.userExpertiseAssocRepository.updateById(id, data);
+    return this.expertiseCatalogService.updateAssignment(id, data);
   }
 
   @put('/userExpertiseAssocs/{id}')
@@ -140,8 +148,9 @@ export class UserExpertiseAssocController {
   ): Promise<void> {
     const assoc = await this.userExpertiseAssocRepository.findById(id);
     await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
+    await this.assertCanManageAssoc(userProfile, Number(data.expertiseId));
 
-    return this.userExpertiseAssocRepository.replaceById(id, data);
+    return this.expertiseCatalogService.updateAssignment(id, data);
   }
 
   @del('/userExpertiseAssocs/{id}')
@@ -153,7 +162,7 @@ export class UserExpertiseAssocController {
     const assoc = await this.userExpertiseAssocRepository.findById(id);
     await this.assertCanManageAssoc(userProfile, assoc.expertiseId);
 
-    return this.userExpertiseAssocRepository.deleteById(id);
+    return this.expertiseCatalogService.removeAssignment(id);
   }
 
   private async scopeAssocFilter(

--- a/api/src/services/expertise-catalog.service.ts
+++ b/api/src/services/expertise-catalog.service.ts
@@ -1,0 +1,200 @@
+import {service} from '@loopback/core';
+import {DataObject, repository} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {Expertise, UserExpertiseAssoc} from '../models';
+import {
+  ExpertiseRepository,
+  UserExpertiseAssocRepository,
+} from '../repositories';
+import {WorkspaceAuthorizationService} from './workspace-authorization.service';
+
+export class ExpertiseCatalogService {
+  constructor(
+    @repository(ExpertiseRepository)
+    private expertiseRepository: ExpertiseRepository,
+    @repository(UserExpertiseAssocRepository)
+    private userExpertiseAssocRepository: UserExpertiseAssocRepository,
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+  ) {}
+
+  async createExpertise(data: DataObject<Expertise>): Promise<Expertise> {
+    const workspaceId = Number(data.workspaceId);
+    const name = this.normalizeName(data.name);
+
+    if (!workspaceId || !name) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Workspace expertise requires a workspace and name.',
+      );
+    }
+
+    await this.assertUniqueExpertiseName(workspaceId, name);
+
+    return this.expertiseRepository.create({
+      ...data,
+      workspaceId,
+      name,
+      description: this.normalizeOptionalText(data.description),
+    });
+  }
+
+  async updateExpertise(
+    id: number,
+    data: DataObject<Expertise>,
+  ): Promise<void> {
+    const existing = await this.expertiseRepository.findById(id);
+    const name =
+      data.name === undefined ? existing.name : this.normalizeName(data.name);
+
+    if (!name) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Workspace expertise requires a name.',
+      );
+    }
+
+    await this.assertUniqueExpertiseName(existing.workspaceId, name, id);
+
+    return this.expertiseRepository.updateById(id, {
+      ...data,
+      workspaceId: existing.workspaceId,
+      name,
+      description:
+        data.description === undefined
+          ? existing.description
+          : this.normalizeOptionalText(data.description),
+    });
+  }
+
+  async replaceExpertise(
+    id: number,
+    data: DataObject<Expertise>,
+  ): Promise<void> {
+    const existing = await this.expertiseRepository.findById(id);
+    const name = this.normalizeName(data.name);
+
+    if (!name) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Workspace expertise requires a name.',
+      );
+    }
+
+    await this.assertUniqueExpertiseName(existing.workspaceId, name, id);
+
+    return this.expertiseRepository.replaceById(id, {
+      ...data,
+      id,
+      workspaceId: existing.workspaceId,
+      name,
+      description: this.normalizeOptionalText(data.description),
+    });
+  }
+
+  async assignExpertise(
+    data: DataObject<UserExpertiseAssoc>,
+  ): Promise<UserExpertiseAssoc> {
+    const userId = Number(data.userId);
+    const expertiseId = Number(data.expertiseId);
+
+    if (!userId || !expertiseId) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Assigning team expertise requires a user and expertise.',
+      );
+    }
+
+    const expertise = await this.expertiseRepository.findById(expertiseId);
+    await this.assertUserCanReceiveExpertise(expertise.workspaceId, userId);
+
+    const existing = await this.userExpertiseAssocRepository.findOne({
+      where: {userId, expertiseId},
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    return this.userExpertiseAssocRepository.create({userId, expertiseId});
+  }
+
+  async updateAssignment(
+    id: number,
+    data: DataObject<UserExpertiseAssoc>,
+  ): Promise<void> {
+    const existing = await this.userExpertiseAssocRepository.findById(id);
+    const userId = Number(data.userId ?? existing.userId);
+    const expertiseId = Number(data.expertiseId ?? existing.expertiseId);
+
+    if (!userId || !expertiseId) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Assigning team expertise requires a user and expertise.',
+      );
+    }
+
+    const expertise = await this.expertiseRepository.findById(expertiseId);
+    await this.assertUserCanReceiveExpertise(expertise.workspaceId, userId);
+
+    const duplicate = await this.userExpertiseAssocRepository.findOne({
+      where: {userId, expertiseId},
+    });
+
+    if (duplicate && duplicate.id !== id) {
+      throw new HttpErrors.Conflict('User already has this team expertise.');
+    }
+
+    return this.userExpertiseAssocRepository.updateById(id, {
+      ...data,
+      userId,
+      expertiseId,
+    });
+  }
+
+  async removeAssignment(id: number): Promise<void> {
+    return this.userExpertiseAssocRepository.deleteById(id);
+  }
+
+  private async assertUniqueExpertiseName(
+    workspaceId: number,
+    name: string,
+    ignoreId?: number,
+  ): Promise<void> {
+    const workspaceExpertises = await this.expertiseRepository.find({
+      where: {workspaceId},
+    });
+    const normalizedName = this.toComparisonKey(name);
+    const duplicate = workspaceExpertises.find(
+      expertise =>
+        expertise.id !== ignoreId &&
+        this.toComparisonKey(expertise.name) === normalizedName,
+    );
+
+    if (duplicate) {
+      throw new HttpErrors.Conflict(
+        'Team expertise already exists in this workspace.',
+      );
+    }
+  }
+
+  private async assertUserCanReceiveExpertise(
+    workspaceId: number,
+    userId: number,
+  ): Promise<void> {
+    await this.workspaceAuthorizationService.assertWorkspaceMember(
+      workspaceId,
+      userId,
+    );
+  }
+
+  private normalizeName(value: string | undefined): string {
+    return (value ?? '').trim().replace(/\s+/g, ' ');
+  }
+
+  private normalizeOptionalText(
+    value: string | null | undefined,
+  ): string | undefined {
+    const normalized = (value ?? '').trim();
+    return normalized.length ? normalized : undefined;
+  }
+
+  private toComparisonKey(value: string | undefined): string {
+    return this.normalizeName(value).toLocaleLowerCase();
+  }
+}

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -11,6 +11,7 @@ export * from './queue.service';
 export * from './capacity-planning-sync.service';
 export * from './communication.service';
 export * from './communication-socket.service';
+export * from './expertise-catalog.service';
 export * from './pr-review-reminder-scheduler.service';
 export * from './pull-request-review-reminder.service';
 export * from './redis.service';

--- a/client/app/components/routes/workspaces/edit/settings.gts
+++ b/client/app/components/routes/workspaces/edit/settings.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
 import { inject as service } from '@ember/service';
 import { eq, not, or } from 'ember-truth-helpers';
 import UiAlert from 'client/components/ui/alert';
@@ -49,7 +50,11 @@ type TeamMembersPage = {
   members: WorkspaceMemberModel[];
 };
 
-type ExpertiseByUserId = Record<number, ExpertiseModel[]>;
+type AssignedExpertise = {
+  associationId: number;
+  expertise: ExpertiseModel;
+};
+type ExpertiseByUserId = Record<number, AssignedExpertise[]>;
 type RoleOption = { id: 'ADMIN' | 'MEMBER'; name: string };
 
 type StoreLike = {
@@ -358,11 +363,21 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
       const userId = Number(association.userId);
       const existing = expertiseByUserId[userId] ?? [];
 
-      if (existing.some((item) => item.id === expertise.id)) {
+      if (
+        existing.some(
+          (item) => Number(item.expertise.id) === Number(expertise.id)
+        )
+      ) {
         return;
       }
 
-      expertiseByUserId[userId] = [...existing, expertise];
+      expertiseByUserId[userId] = [
+        ...existing,
+        {
+          associationId: Number(association.id),
+          expertise,
+        },
+      ];
     });
 
     this.expertiseByUserId = expertiseByUserId;
@@ -370,7 +385,7 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
 
   createExpertiseTask = task(async () => {
     const workspaceId = Number(this.args.model.id);
-    const name = this.expertiseName.trim();
+    const name = this.normalizeExpertiseName(this.expertiseName);
     const description = this.expertiseDescription.trim();
 
     if (!workspaceId || !name) {
@@ -379,20 +394,14 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
 
     this.expertisePanelError = null;
 
-    const existingExpertises = Array.from(
-      await this.store.query('expertise', {
-        filter: {
-          where: {
-            workspaceId,
-            name,
-          },
-          limit: 1,
-        },
-      })
+    const existingExpertise = this.workspaceExpertises.find(
+      (expertise) =>
+        this.normalizeExpertiseName(expertise.name).toLocaleLowerCase() ===
+        name.toLocaleLowerCase()
     );
 
     const expertise =
-      existingExpertises[0] ??
+      existingExpertise ??
       (await this.store.saveRecord(
         this.store.createRecord('expertise', {
           name,
@@ -407,7 +416,7 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
     this.expertiseDescription = '';
 
     this.flashMessages.success?.(`${expertise.name} is available to assign.`, {
-      title: existingExpertises[0]
+      title: existingExpertise
         ? 'Expertise already exists'
         : 'Expertise created',
     });
@@ -426,11 +435,15 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
 
     const currentExpertises = this.expertiseForUser(userId);
 
-    if (currentExpertises.some((item) => Number(item.id) === expertiseId)) {
+    if (
+      currentExpertises.some(
+        (item) => Number(item.expertise.id) === expertiseId
+      )
+    ) {
       throw new Error(`${member.user.fullName} already has this expertise.`);
     }
 
-    await this.store.saveRecord(
+    const association = await this.store.saveRecord(
       this.store.createRecord('user-expertise-assoc', {
         userId,
         expertiseId,
@@ -439,7 +452,13 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
 
     this.expertiseByUserId = {
       ...this.expertiseByUserId,
-      [userId]: [...currentExpertises, expertise],
+      [userId]: [
+        ...currentExpertises,
+        {
+          associationId: Number(association.id),
+          expertise,
+        },
+      ],
     };
     this.selectedExpertiseIdByUserId = {
       ...this.selectedExpertiseIdByUserId,
@@ -453,6 +472,34 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
       }
     );
   });
+
+  removeExpertiseTask = task(
+    async (member: TeamMemberCard, assignedExpertise: AssignedExpertise) => {
+      const userId = Number(member.user.id);
+
+      await this.api.request(
+        `/userExpertiseAssocs/${assignedExpertise.associationId}`,
+        {
+          method: 'DELETE',
+        }
+      );
+
+      const currentExpertises = this.expertiseForUser(userId);
+      this.expertiseByUserId = {
+        ...this.expertiseByUserId,
+        [userId]: currentExpertises.filter(
+          (item) => item.associationId !== assignedExpertise.associationId
+        ),
+      };
+
+      this.flashMessages.success?.(
+        `${assignedExpertise.expertise.name} removed from ${member.user.fullName}.`,
+        {
+          title: 'Expertise removed',
+        }
+      );
+    }
+  );
 
   removeWorkspaceMemberTask = task(async (member: TeamMemberCard) => {
     const workspaceMemberId = Number(member.workspaceMember?.id);
@@ -577,7 +624,7 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
     return cards;
   }
 
-  get selectedUserExpertises(): ExpertiseModel[] {
+  get selectedUserExpertises(): AssignedExpertise[] {
     const userId = Number(this.expertisePanelUser?.user.id ?? 0);
 
     return this.expertiseForUser(userId);
@@ -659,7 +706,7 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
     }
   };
 
-  expertiseForUser = (userId: number): ExpertiseModel[] => {
+  expertiseForUser = (userId: number): AssignedExpertise[] => {
     return this.expertiseByUserId[userId] ?? [];
   };
 
@@ -719,13 +766,24 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
   }
 
   mergeWorkspaceExpertise(expertise: ExpertiseModel): void {
-    if (this.workspaceExpertises.some((item) => item.id === expertise.id)) {
+    if (
+      this.workspaceExpertises.some(
+        (item) =>
+          item.id === expertise.id ||
+          this.normalizeExpertiseName(item.name).toLocaleLowerCase() ===
+            this.normalizeExpertiseName(expertise.name).toLocaleLowerCase()
+      )
+    ) {
       return;
     }
 
     this.workspaceExpertises = [...this.workspaceExpertises, expertise].sort(
       (a, b) => a.name.localeCompare(b.name)
     );
+  }
+
+  normalizeExpertiseName(value: string): string {
+    return value.trim().replace(/\s+/g, ' ');
   }
 
   async uploadAvatar(workspaceId: number, file: File): Promise<{ id: number }> {
@@ -852,6 +910,30 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
       this.expertisePanelError =
         error instanceof Error ? error.message : 'Failed to assign expertise.';
     });
+  }
+
+  @action
+  removeExpertise(
+    member: TeamMemberCard,
+    assignedExpertise: AssignedExpertise
+  ): void {
+    this.removeExpertiseTask
+      .perform(member, assignedExpertise)
+      .catch((error: unknown) => {
+        this.expertisePanelError =
+          error instanceof Error
+            ? error.message
+            : 'Failed to remove expertise.';
+      });
+  }
+
+  @action
+  removeSelectedUserExpertise(assignedExpertise: AssignedExpertise): void {
+    if (!this.expertisePanelUser) {
+      return;
+    }
+
+    this.removeExpertise(this.expertisePanelUser, assignedExpertise);
   }
 
   @action
@@ -1309,7 +1391,22 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
                                     as |expertise|
                                   }}
                                     <span class="settings-expertise-chip">
-                                      {{expertise.name}}
+                                      {{expertise.expertise.name}}
+                                      <button
+                                        type="button"
+                                        class="settings-expertise-chip__remove"
+                                        {{on
+                                          "click"
+                                          (fn
+                                            this.removeExpertise
+                                            member
+                                            expertise
+                                          )
+                                        }}
+                                        aria-label="Remove {{expertise.expertise.name}} from {{member.user.fullName}}"
+                                      >
+                                        <UiIcon @name="x" />
+                                      </button>
                                     </span>
                                   {{else}}
                                     <span
@@ -1497,7 +1594,18 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
                   <div class="settings-member-card__chips">
                     {{#each this.selectedUserExpertises as |expertise|}}
                       <span class="settings-expertise-chip --panel">
-                        {{expertise.name}}
+                        {{expertise.expertise.name}}
+                        <button
+                          type="button"
+                          class="settings-expertise-chip__remove"
+                          {{on
+                            "click"
+                            (fn this.removeSelectedUserExpertise expertise)
+                          }}
+                          aria-label="Remove {{expertise.expertise.name}}"
+                        >
+                          <UiIcon @name="x" />
+                        </button>
                       </span>
                     {{else}}
                       <span class="font-color-text-secondary font-size-text-sm">

--- a/client/app/styles/routes/workspaces/settings.css
+++ b/client/app/styles/routes/workspaces/settings.css
@@ -341,6 +341,7 @@
   .settings-expertise-chip {
     display: inline-flex;
     align-items: center;
+    gap: var(--space-xs);
     min-height: 2.4rem;
     padding: 0.35rem 0.9rem;
     border-radius: var(--radius-sm);
@@ -353,6 +354,25 @@
 
     &.--panel {
       background: color-mix(in srgb, var(--bg-surface) 88%, white 12%);
+    }
+  }
+
+  .settings-expertise-chip__remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      background: var(--bg-app);
+      color: var(--text-primary);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR normalizes the role/expertise domain around the workspace expertise catalog.

It introduces a centralized `ExpertiseCatalogService`, enforces case-insensitive unique expertise names per workspace, deduplicates existing expertise data, and updates the settings UI to make team expertise assignment/removal clearer.

## What changed

- Added a migration that deduplicates existing workspace expertise records by normalized name.
- Reassigns existing user-expertise associations from duplicate expertise records to the kept canonical expertise record.
- Removes duplicate user-expertise associations before remapping expertise IDs.
- Adds a unique index on `(workspace_id, lower(trim(name)))`.
- Added `ExpertiseCatalogService` to centralize:
  - expertise creation
  - expertise update/replace behavior
  - expertise name normalization
  - duplicate expertise validation
  - user expertise assignment
  - user expertise assignment updates
  - user expertise removal
- Normalizes expertise names by trimming and collapsing repeated whitespace.
- Normalizes empty descriptions to `undefined`.
- Prevents case-insensitive duplicate expertise names within the same workspace.
- Keeps expertise records in their original workspace during updates/replacements.
- Ensures users can only receive expertise for workspaces they belong to.
- Makes assigning the same expertise idempotent by returning the existing assignment.
- Prevents assignment updates that would duplicate an existing user/expertise pair.
- Updated `ExpertiseController` to delegate create/update/replace behavior to `ExpertiseCatalogService`.
- Updated `UserExpertiseAssocController` to delegate assignment/update/delete behavior to `ExpertiseCatalogService`.
- Updated settings UI to:
  - use normalized expertise names
  - avoid creating duplicate expertise records client-side
  - track assignment IDs alongside expertise records
  - support removing expertise from users
  - improve team expertise copy and styling
- Added unit tests for expertise normalization, duplicate prevention, assignment idempotency, assignment updates, and controller delegation.

## Why

The functional spec refers to team roles, while the current implementation uses expertise. This PR keeps the existing expertise model but makes it behave like a clean workspace-level team expertise catalog.

That gives the app a consistent contract for AI recommendations, user assignments, and settings management while preventing duplicate catalog entries such as `Backend`, ` backend `, and `BACKEND`.

## Testing

Added or updated test coverage for:

- case-insensitive duplicate expertise validation
- whitespace normalization for expertise names
- description normalization
- preserving workspace ownership during expertise updates
- idempotent user expertise assignment
- duplicate assignment prevention
- removing expertise assignments
- controller delegation to `ExpertiseCatalogService`
- migration-backed uniqueness through the new database index

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Very-High
> Reason: This PR introduces database migrations that modify unique constraints and deduplicate existing expertise records, which carries significant rollback and data integrity risks. The SQL migration includes complex deduplication logic using window functions and conditional updates/deletes that could affect production data if incorrect. Additionally, the introduction of a new service (ExpertiseCatalogService) and modifications to core controllers increase the operational risk.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->