### PR TITLE
Add owner-only workspace deletion

### DIFF
--- a/api/migrations/20260513110000-workspace-soft-delete.js
+++ b/api/migrations/20260513110000-workspace-soft-delete.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options) {
+  Promise = options.Promise;
+};
+
+function runSqlFile(db, fileName) {
+  var filePath = path.join(__dirname, 'sqls', fileName);
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err, data) {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+}
+
+exports.up = function(db) {
+  return runSqlFile(db, '20260513110000-workspace-soft-delete-up.sql');
+};
+
+exports.down = function(db) {
+  return runSqlFile(db, '20260513110000-workspace-soft-delete-down.sql');
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/sqls/20260513110000-workspace-soft-delete-down.sql
+++ b/api/migrations/sqls/20260513110000-workspace-soft-delete-down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS "system"."workspace_active_owner_idx";
+
+ALTER TABLE "system"."workspace"
+  DROP COLUMN IF EXISTS deleted_at;

--- a/api/migrations/sqls/20260513110000-workspace-soft-delete-up.sql
+++ b/api/migrations/sqls/20260513110000-workspace-soft-delete-up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "system"."workspace"
+  ADD COLUMN IF NOT EXISTS deleted_at timestamp with time zone;
+
+CREATE INDEX IF NOT EXISTS workspace_active_owner_idx
+  ON "system"."workspace"(owner_id)
+  WHERE deleted_at IS NULL;

--- a/api/src/__tests__/unit/controllers/workspace.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/workspace.controller.test.ts
@@ -25,15 +25,20 @@ describe('WorkspaceController (unit)', () => {
     const auditEventService = {
       record: vi.fn().mockResolvedValue(undefined),
     };
+    const workspaceService = {
+      softDeleteWorkspace: vi.fn().mockResolvedValue(undefined),
+    };
 
     return {
       repository,
       authorization,
       auditEventService,
+      workspaceService,
       controller: new WorkspaceController(
         repository as never,
         authorization as never,
         auditEventService as never,
+        workspaceService as never,
       ),
     };
   };
@@ -101,10 +106,10 @@ describe('WorkspaceController (unit)', () => {
     );
   });
 
-  it('audits workspace replacement and deletion', async () => {
-    const {controller, repository, auditEventService} = createController();
+  it('audits workspace replacement and soft deletion', async () => {
+    const {controller, repository, auditEventService, workspaceService} =
+      createController();
     repository.replaceById.mockResolvedValue(undefined);
-    repository.deleteById.mockResolvedValue(undefined);
 
     await expect(
       controller.replaceById({id: 7} as never, 11, {
@@ -112,7 +117,7 @@ describe('WorkspaceController (unit)', () => {
       }),
     ).resolves.toBeUndefined();
     await expect(
-      controller.deleteById({id: 7} as never, 11),
+      controller.deleteById({id: 7} as never, 11, 'Demo'),
     ).resolves.toBeUndefined();
 
     expect(auditEventService.record).toHaveBeenCalledWith(
@@ -121,11 +126,10 @@ describe('WorkspaceController (unit)', () => {
         resourceId: '11',
       }),
     );
-    expect(auditEventService.record).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: 'workspace.deleted',
-        resourceId: '11',
-      }),
-    );
+    expect(workspaceService.softDeleteWorkspace).toHaveBeenCalledWith({
+      workspaceId: 11,
+      actorUserId: 7,
+      confirmationName: 'Demo',
+    });
   });
 });

--- a/api/src/__tests__/unit/services/workspace-authorization.service.test.ts
+++ b/api/src/__tests__/unit/services/workspace-authorization.service.test.ts
@@ -81,6 +81,21 @@ describe('WorkspaceAuthorizationService (unit)', () => {
     );
   });
 
+  it('denies access to soft-deleted workspaces', async () => {
+    const {service, workspaceRepository, workspaceMemberRepository} =
+      createService();
+    workspaceRepository.findById.mockResolvedValue({
+      id: 3,
+      ownerId: 7,
+      deletedAt: new Date(),
+    });
+
+    await expect(
+      service.checkPermission(3, 7, WORKSPACE_PERMISSION.WORKSPACE_VIEW),
+    ).resolves.toMatchObject({allowed: false, role: null});
+    expect(workspaceMemberRepository.findOne).not.toHaveBeenCalled();
+  });
+
   it('merges workspace access into filters', async () => {
     const {service, workspaceMemberRepository} = createService();
     workspaceMemberRepository.find.mockResolvedValue([
@@ -92,7 +107,12 @@ describe('WorkspaceAuthorizationService (unit)', () => {
       service.mergeWorkspaceAccessFilter({where: {name: 'API'}}, 7),
     ).resolves.toEqual({
       where: {
-        and: [{name: 'API'}, {or: [{ownerId: 7}, {id: {inq: [3, 4]}}]}],
+        and: [
+          {name: 'API'},
+          {
+            and: [{deletedAt: null}, {or: [{ownerId: 7}, {id: {inq: [3, 4]}}]}],
+          },
+        ],
       },
     });
   });

--- a/api/src/__tests__/unit/services/workspace.service.test.ts
+++ b/api/src/__tests__/unit/services/workspace.service.test.ts
@@ -1,0 +1,124 @@
+import {HttpErrors} from '@loopback/rest';
+import {describe, expect, it, vi} from 'vitest';
+
+import {Workspace} from '../../../models';
+import {WorkspaceService} from '../../../services/workspace.service';
+
+const createService = (workspace: Workspace) => {
+  const workspaceRepository = {
+    findById: vi.fn().mockResolvedValue(workspace),
+    updateById: vi.fn().mockResolvedValue(undefined),
+  };
+  const workspaceAuthorizationService = {
+    assertWorkspaceOwner: vi.fn().mockResolvedValue('OWNER'),
+  };
+  const auditEventService = {
+    record: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    service: new WorkspaceService(
+      workspaceRepository as never,
+      workspaceAuthorizationService as never,
+      auditEventService as never,
+    ),
+    workspaceRepository,
+    workspaceAuthorizationService,
+    auditEventService,
+  };
+};
+
+describe('WorkspaceService (unit)', () => {
+  it('soft-deletes a workspace and disconnects sync settings', async () => {
+    const workspace = new Workspace({
+      id: 11,
+      name: 'Demo',
+      ownerId: 7,
+      githubInstallationId: '123',
+      issueSync: true,
+      capacityPlanningSync: true,
+      prRiskPredictionSync: true,
+      reviewerSuggestionSync: true,
+      prReviewReminderCron: '*/5 * * * *',
+    });
+    const {
+      service,
+      workspaceRepository,
+      workspaceAuthorizationService,
+      auditEventService,
+    } = createService(workspace);
+
+    await service.softDeleteWorkspace({
+      workspaceId: 11,
+      actorUserId: 7,
+      confirmationName: 'Demo',
+    });
+
+    expect(
+      workspaceAuthorizationService.assertWorkspaceOwner,
+    ).toHaveBeenCalledWith(11, 7);
+    expect(workspaceRepository.updateById).toHaveBeenCalledWith(
+      11,
+      expect.objectContaining({
+        githubInstallationId: undefined,
+        issueSync: false,
+        issueSyncDone: false,
+        prSyncDone: false,
+        capacityPlanningSync: false,
+        prRiskPredictionSync: false,
+        reviewerSuggestionSync: false,
+        prReviewReminderCron: undefined,
+      }),
+    );
+    expect(
+      workspaceRepository.updateById.mock.calls[0]?.[1].deletedAt,
+    ).toBeInstanceOf(Date);
+    expect(auditEventService.record).toHaveBeenCalledWith({
+      actorUserId: 7,
+      workspaceId: 11,
+      action: 'workspace.deleted',
+      resourceType: 'workspace',
+      resourceId: '11',
+      payload: {
+        name: 'Demo',
+        deletionPolicy: 'soft-delete',
+        filesPolicy: 'retained',
+      },
+    });
+  });
+
+  it('rejects mismatched workspace name confirmation', async () => {
+    const {service, workspaceRepository} = createService(
+      new Workspace({id: 11, name: 'Demo', ownerId: 7}),
+    );
+
+    await expect(
+      service.softDeleteWorkspace({
+        workspaceId: 11,
+        actorUserId: 7,
+        confirmationName: 'Other',
+      }),
+    ).rejects.toBeInstanceOf(HttpErrors.UnprocessableEntity);
+
+    expect(workspaceRepository.updateById).not.toHaveBeenCalled();
+  });
+
+  it('does not delete an already deleted workspace again', async () => {
+    const {service, workspaceRepository, auditEventService} = createService(
+      new Workspace({
+        id: 11,
+        name: 'Demo',
+        ownerId: 7,
+        deletedAt: new Date(),
+      }),
+    );
+
+    await service.softDeleteWorkspace({
+      workspaceId: 11,
+      actorUserId: 7,
+    });
+
+    expect(workspaceRepository.updateById).not.toHaveBeenCalled();
+    expect(auditEventService.record).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/controllers/system/workspace.controller.ts
+++ b/api/src/controllers/system/workspace.controller.ts
@@ -8,7 +8,11 @@ import {SecurityBindings, UserProfile} from '@loopback/security';
 import {WORKSPACE_PERMISSION} from '../../constants';
 import {Workspace, WorkspaceRelations} from '../../models';
 import {WorkspaceRepository} from '../../repositories';
-import {AuditEventService, WorkspaceAuthorizationService} from '../../services';
+import {
+  AuditEventService,
+  WorkspaceAuthorizationService,
+  WorkspaceService,
+} from '../../services';
 import {WORKSPACE_AUTHORIZER} from '../../authorization/workspace-authorizer.provider';
 
 const OWNER_ONLY_WORKSPACE_FIELDS = new Set<keyof Workspace>([
@@ -31,6 +35,8 @@ export class WorkspaceController {
     private workspaceAuthorizationService: WorkspaceAuthorizationService,
     @inject('services.AuditEventService')
     private auditEventService: AuditEventService,
+    @inject('services.WorkspaceService')
+    private workspaceService: WorkspaceService,
   ) {}
 
   @get('/workspaces')
@@ -220,17 +226,15 @@ export class WorkspaceController {
     @inject(SecurityBindings.USER)
     userProfile: UserProfile,
     @param.path.number('id') id: number,
+    @param.query.string('confirmationName') confirmationName?: string,
   ): Promise<void> {
-    await this.workspaceRepository.deleteById(id);
-
     const userId =
       this.workspaceAuthorizationService.getAuthenticatedUserId(userProfile);
-    await this.auditEventService.record({
-      actorUserId: userId,
+
+    await this.workspaceService.softDeleteWorkspace({
       workspaceId: id,
-      action: 'workspace.deleted',
-      resourceType: 'workspace',
-      resourceId: String(id),
+      actorUserId: userId,
+      confirmationName,
     });
   }
 

--- a/api/src/models/system/workspace.model.ts
+++ b/api/src/models/system/workspace.model.ts
@@ -103,6 +103,12 @@ export class Workspace extends Entity {
   })
   reviewerSuggestionSync?: boolean;
 
+  @property({
+    type: 'date',
+    postgresql: {columnName: 'deleted_at'},
+  })
+  deletedAt?: Date;
+
   @hasMany(() => File, {keyTo: 'workspaceId'})
   files?: File[];
 

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -16,3 +16,4 @@ export * from './pr-review-reminder-scheduler.service';
 export * from './pull-request-review-reminder.service';
 export * from './redis.service';
 export * from './workspace-authorization.service';
+export * from './workspace.service';

--- a/api/src/services/workspace-authorization.service.ts
+++ b/api/src/services/workspace-authorization.service.ts
@@ -132,6 +132,10 @@ export class WorkspaceAuthorizationService {
   ): Promise<WorkspaceRole | null> {
     const workspace = await this.workspaceRepository.findById(workspaceId);
 
+    if (workspace.deletedAt) {
+      return null;
+    }
+
     if (workspace.ownerId === userId) {
       return WORKSPACE_ROLE.OWNER;
     }
@@ -159,7 +163,12 @@ export class WorkspaceAuthorizationService {
       .filter((workspaceId): workspaceId is number => workspaceId != null);
 
     return {
-      or: [{ownerId: userId}, {id: {inq: workspaceIds}}],
+      and: [
+        {deletedAt: null as never},
+        {
+          or: [{ownerId: userId}, {id: {inq: workspaceIds}}],
+        },
+      ],
     };
   }
 

--- a/api/src/services/workspace.service.ts
+++ b/api/src/services/workspace.service.ts
@@ -1,0 +1,77 @@
+import {service} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {Workspace} from '../models';
+import {WorkspaceRepository} from '../repositories';
+import {AuditEventService} from './audit-event.service';
+import {WorkspaceAuthorizationService} from './workspace-authorization.service';
+
+export type DeleteWorkspaceInput = {
+  workspaceId: number;
+  actorUserId: number;
+  confirmationName?: string;
+};
+
+export class WorkspaceService {
+  constructor(
+    @repository(WorkspaceRepository)
+    private workspaceRepository: WorkspaceRepository,
+    @service(WorkspaceAuthorizationService)
+    private workspaceAuthorizationService: WorkspaceAuthorizationService,
+    @service(AuditEventService)
+    private auditEventService: AuditEventService,
+  ) {}
+
+  async softDeleteWorkspace(input: DeleteWorkspaceInput): Promise<void> {
+    const workspace = await this.workspaceRepository.findById(
+      input.workspaceId,
+    );
+
+    if (workspace.deletedAt) {
+      return;
+    }
+
+    await this.workspaceAuthorizationService.assertWorkspaceOwner(
+      input.workspaceId,
+      input.actorUserId,
+    );
+
+    if (
+      input.confirmationName !== undefined &&
+      input.confirmationName !== workspace.name
+    ) {
+      throw new HttpErrors.UnprocessableEntity(
+        'Workspace name confirmation does not match.',
+      );
+    }
+
+    await this.disconnectWorkspace(workspace);
+
+    await this.auditEventService.record({
+      actorUserId: input.actorUserId,
+      workspaceId: workspace.id,
+      action: 'workspace.deleted',
+      resourceType: 'workspace',
+      resourceId: String(workspace.id),
+      payload: {
+        name: workspace.name,
+        deletionPolicy: 'soft-delete',
+        filesPolicy: 'retained',
+      },
+    });
+  }
+
+  private async disconnectWorkspace(workspace: Workspace): Promise<void> {
+    await this.workspaceRepository.updateById(workspace.id, {
+      deletedAt: new Date(),
+      githubInstallationId: undefined,
+      issueSync: false,
+      issueSyncDone: false,
+      prSyncDone: false,
+      capacityPlanningSync: false,
+      prRiskPredictionSync: false,
+      reviewerSuggestionSync: false,
+      prReviewReminderCron: undefined,
+    });
+  }
+}

--- a/client/app/components/routes/workspaces/edit/settings.gts
+++ b/client/app/components/routes/workspaces/edit/settings.gts
@@ -27,6 +27,7 @@ import type WorkspaceModel from 'client/models/workspace';
 import type {
   ApiServiceLike,
   FlashMessagesServiceLike,
+  RouterServiceLike,
 } from 'client/types/services';
 import { task } from 'ember-concurrency';
 import { task as trackedTask } from 'reactiveweb/ember-concurrency';
@@ -116,6 +117,10 @@ type SessionServiceLike = {
   };
 };
 
+type LastWorkspaceServiceLike = {
+  clear(): void;
+};
+
 export interface RoutesWorkspacesEditSettingsSignature {
   Args: {
     model: WorkspaceModel;
@@ -129,6 +134,8 @@ export interface RoutesWorkspacesEditSettingsSignature {
 export default class RoutesWorkspacesEditSettings extends Component<RoutesWorkspacesEditSettingsSignature> {
   @service declare store: StoreLike;
   @service declare api: ApiWithFilesServiceLike;
+  @service declare lastWorkspace: LastWorkspaceServiceLike;
+  @service declare router: RouterServiceLike;
   @service declare session: SessionServiceLike;
   @service declare flashMessages: FlashMessagesServiceLike;
 
@@ -160,6 +167,7 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
   @tracked roleUpdateInFlightId: string | null = null;
   @tracked memberRemovalInFlightId: string | null = null;
   @tracked removedWorkspaceMemberIds: number[] = [];
+  @tracked workspaceDeleteConfirmation = '';
 
   readonly pageSize = 4;
   readonly memberRoleOptions: RoleOption[] = [
@@ -536,6 +544,28 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
     );
   });
 
+  deleteWorkspaceTask = task(async () => {
+    const workspaceId = Number(this.args.model.id);
+    const workspaceName = this.args.model.name;
+
+    if (!workspaceId || !this.canDeleteWorkspace) {
+      throw new Error('Type the workspace name to confirm deletion.');
+    }
+
+    await this.api.request(`/workspaces/${workspaceId}`, {
+      method: 'DELETE',
+      params: {
+        confirmationName: workspaceName,
+      },
+    });
+
+    this.lastWorkspace.clear();
+    this.flashMessages.success?.(`${workspaceName} was deleted.`, {
+      title: 'Workspace deleted',
+    });
+    this.router.transitionTo('workspaces.index');
+  });
+
   updateMemberRoleTask = task(
     async (member: TeamMemberCard, option: DropdownOption | null) => {
       const roleOption = this.asRoleOption(option);
@@ -670,6 +700,10 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
 
   get canAddExpertise(): boolean {
     return this.expertiseName.trim().length > 0;
+  }
+
+  get canDeleteWorkspace(): boolean {
+    return this.workspaceDeleteConfirmation.trim() === this.args.model.name;
   }
 
   get expertiseOptions(): DropdownOption[] {
@@ -856,6 +890,23 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
   @action
   updateInvitationEmail(value: string): void {
     this.invitationEmail = value;
+  }
+
+  @action
+  updateWorkspaceDeleteConfirmation(value: string): void {
+    this.workspaceDeleteConfirmation = value;
+  }
+
+  @action
+  deleteWorkspace(): void {
+    this.deleteWorkspaceTask.perform().catch((error: unknown) => {
+      this.flashMessages.danger(
+        error instanceof Error ? error.message : 'Failed to delete workspace.',
+        {
+          title: 'Workspace deletion failed',
+        }
+      );
+    });
   }
 
   @action
@@ -1112,6 +1163,42 @@ export default class RoutesWorkspacesEditSettings extends Component<RoutesWorksp
                           (not this.hasWorkspaceChanges)
                         }}
                       />
+                    </div>
+
+                    <div class="settings-danger-zone">
+                      <div class="layout-vertical --gap-xs">
+                        <div class="layout-horizontal --gap-sm">
+                          <UiIcon @name="alert-triangle" @variant="error" />
+                          <h3 class="margin-zero">Danger Zone</h3>
+                        </div>
+                        <span class="font-color-text-secondary">
+                          Deleting a workspace hides it from the app and
+                          disconnects GitHub sync. Files and audit history are
+                          retained as tombstoned records.
+                        </span>
+                      </div>
+
+                      <UiFormGroup
+                        @label="Type {{@model.name}} to confirm"
+                        @trailingText="Only the workspace owner can delete this workspace."
+                      >
+                        <UiInput
+                          @value={{this.workspaceDeleteConfirmation}}
+                          @onInput={{this.updateWorkspaceDeleteConfirmation}}
+                          @placeholder={{@model.name}}
+                        />
+                      </UiFormGroup>
+
+                      <div class="settings-actions-row">
+                        <UiButton
+                          @text="Delete workspace"
+                          @hierarchy="secondary"
+                          @iconLeft="trash"
+                          @onClick={{this.deleteWorkspace}}
+                          @loading={{this.deleteWorkspaceTask.isRunning}}
+                          @disabled={{not this.canDeleteWorkspace}}
+                        />
+                      </div>
                     </div>
                   </div>
                 </:default>

--- a/client/app/models/workspace.ts
+++ b/client/app/models/workspace.ts
@@ -34,4 +34,5 @@ export default class WorkspaceModel extends Model {
   @attr('boolean') declare capacityPlanningSync: boolean;
   @attr('boolean') declare prRiskPredictionSync: boolean;
   @attr('boolean') declare reviewerSuggestionSync: boolean;
+  @attr('date') declare deletedAt: Date | null;
 }

--- a/client/app/styles/routes/workspaces/settings.css
+++ b/client/app/styles/routes/workspaces/settings.css
@@ -160,6 +160,15 @@
     justify-content: flex-end;
   }
 
+  .settings-danger-zone {
+    display: grid;
+    gap: var(--space-md);
+    padding: var(--space-lg);
+    border: 1px solid color-mix(in srgb, var(--color-error) 42%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--color-error-bg) 14%, transparent);
+  }
+
   .settings-members-summary {
     display: flex;
     gap: var(--space-md);


### PR DESCRIPTION
## Summary

This PR adds owner-only workspace deletion.

Workspaces are now soft-deleted instead of hard-deleted. Deleting a workspace hides it from active workspace queries, blocks future authorization access, disconnects GitHub/sync settings, retains files and audit history, and records an audit event.

## What changed

- Added a `deleted_at` column to `system.workspace`.
- Added an index for active owner workspace lookups.
- Added `deletedAt` to the backend `Workspace` model.
- Added `deletedAt` to the client `Workspace` model.
- Added `WorkspaceService` to centralize workspace deletion behavior.
- Replaced direct workspace deletion with `softDeleteWorkspace`.
- Restricted workspace deletion to workspace owners only.
- Added optional workspace name confirmation before deletion.
- Made already-deleted workspaces no-op on repeated delete attempts.
- Updated workspace authorization to deny access to soft-deleted workspaces.
- Updated workspace access filters to exclude soft-deleted workspaces.
- Soft deletion now disconnects workspace integration/sync settings by clearing or disabling:
  - GitHub installation id
  - issue sync
  - issue sync completion flag
  - PR sync completion flag
  - capacity planning sync
  - PR risk prediction sync
  - reviewer suggestion sync
  - PR review reminder cron
- Added audit logging for workspace deletion.
- Documented the deletion policy in the audit payload:
  - workspace deletion uses soft delete
  - files are retained
- Added a workspace settings danger zone.
- Added typed workspace-name confirmation in the client before deletion.
- Clears the last selected workspace after deletion.
- Redirects the user back to the workspace index after deletion.
- Added styling for the danger zone UI.
- Added unit tests for workspace soft deletion, confirmation mismatch, already-deleted behavior, controller delegation, and deleted-workspace authorization behavior.

## Why

Workspace deletion is a destructive action and should not remove important historical data accidentally.

This PR gives owners a safe deletion flow by hiding the workspace from the app while preserving files, audit history, and tombstoned records for traceability.

## Testing

Added or updated test coverage for:

- owner-only workspace soft deletion
- disconnecting GitHub and sync settings on deletion
- audit event creation for workspace deletion
- deletion confirmation name mismatch
- repeated delete attempts on already-deleted workspaces
- controller delegation to `WorkspaceService`
- denied authorization for soft-deleted workspaces
- active workspace access filters excluding soft-deleted workspaces

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: High
> Reason: This PR introduces workspace soft-deletion logic including a new migration (api/migrations/20260513110000-workspace-soft-delete.js) that adds a 'deleted_at' column and index, modifies authorization logic to deny access to soft-deleted workspaces (api/src/services/workspace-authorization.service.ts), and adds a new WorkspaceService with soft deletion functionality (api/src/services/workspace.service.ts). The changes span across 14 files and touch critical data handling and authorization paths.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->