### PR TITLE
Harden News-Feed tests

### DIFF
--- a/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/news-feed-entry.controller.test.ts
@@ -1,4 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {HttpErrors} from '@loopback/rest';
 
 import {NewsFeedEntryController} from '../../../controllers';
 import {NewsFeedEntry} from '../../../models';
@@ -91,6 +92,34 @@ describe('NewsFeedEntryController (unit)', () => {
 
     expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 9);
     expect(repository.findPersonalizedFeed).toHaveBeenCalledWith(3, 9);
+  });
+
+  it('derives the feed user from the authenticated session', async () => {
+    authorization.getAuthenticatedUserId.mockReturnValueOnce(42);
+    repository.findPersonalizedFeed.mockResolvedValue([entry]);
+
+    await expect(controller.feed({id: 42} as never, 3)).resolves.toEqual([
+      entry,
+    ]);
+
+    expect(authorization.getAuthenticatedUserId).toHaveBeenCalledWith({
+      id: 42,
+    });
+    expect(authorization.assertWorkspaceMember).toHaveBeenCalledWith(3, 42);
+    expect(repository.findPersonalizedFeed).toHaveBeenCalledWith(3, 42);
+    expect(repository.findPersonalizedFeed).not.toHaveBeenCalledWith(3, 9);
+  });
+
+  it('does not load personalized feed entries for non-members', async () => {
+    authorization.assertWorkspaceMember.mockRejectedValueOnce(
+      new HttpErrors.Forbidden('You are not a member of this workspace.'),
+    );
+
+    await expect(controller.feed({id: 9} as never, 3)).rejects.toBeInstanceOf(
+      HttpErrors.Forbidden,
+    );
+
+    expect(repository.findPersonalizedFeed).not.toHaveBeenCalled();
   });
 
   it('requires workspace membership before returning a single entry', async () => {

--- a/api/src/__tests__/unit/repositories/news-feed.repository.test.ts
+++ b/api/src/__tests__/unit/repositories/news-feed.repository.test.ts
@@ -205,6 +205,44 @@ describe('News feed repositories (unit)', () => {
     expect(entries.map(entry => entry.id)).toEqual([11]);
   });
 
+  it('falls back to workspace entries when user expertises belong to another workspace', async () => {
+    const userExpertiseAssocRepositoryGetter = vi.fn().mockResolvedValue({
+      find: vi.fn().mockResolvedValue([
+        {
+          expertiseId: 4,
+          expertise: {id: 4, workspaceId: 99},
+        },
+      ]),
+    });
+    const repository = new NewsFeedEntryRepository(
+      dataSource as never,
+      async () => ({}) as never,
+      userExpertiseAssocRepositoryGetter as never,
+    );
+    const fallbackEntries = [
+      new NewsFeedEntry({
+        id: 21,
+        workspaceId: 9,
+        sourceType: 'github-issue',
+        sourceId: 41,
+        eventAction: 'created',
+        title: 'Workspace item',
+        summary: 'Workspace item',
+        sourcePriority: 'medium',
+        happenedAt: '2026-04-16T09:00:00.000Z',
+      }),
+    ];
+    const findSpy = vi
+      .spyOn(repository, 'find')
+      .mockResolvedValue(fallbackEntries);
+
+    await expect(repository.findPersonalizedFeed(9, 6)).resolves.toEqual(
+      fallbackEntries,
+    );
+
+    expect(findSpy).toHaveBeenCalledWith({where: {workspaceId: 9}});
+  });
+
   it('registers news feed entry expertise association relations', () => {
     const repository = new NewsFeedEntryExpertiseAssocRepository(
       dataSource as never,


### PR DESCRIPTION
## Summary

This PR hardens news-feed personalization tests.

It adds coverage to ensure personalized feed loading uses the authenticated user, rejects non-members before querying feed data, and safely falls back to workspace-level entries when a user's expertise associations belong to another workspace.

## What changed

- Added controller coverage proving the feed user is derived from the authenticated session.
- Added controller coverage proving the personalized feed checks workspace membership before loading entries.
- Added controller coverage ensuring non-members cannot trigger personalized feed repository queries.
- Added repository coverage for cross-workspace expertise associations.
- Verified that user expertise from another workspace does not leak or incorrectly filter the target workspace feed.
- Verified fallback behavior returns general workspace entries when no relevant in-workspace expertise match exists.

## Why

The personalized news feed depends on both the current user and workspace expertise assignments.

These tests protect the feed from regressions where a client-supplied or stale user context could affect personalization, or where expertise from another workspace could accidentally influence feed results.

## Testing

Added unit test coverage for:

- deriving personalized feed user id from the authenticated session
- enforcing workspace membership before feed lookup
- preventing repository calls for non-members
- ignoring user expertise associations from other workspaces
- falling back to workspace entries when expertise filtering is not applicable

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Low
> Reason: The pull request adds new unit tests to harden existing functionality. The changes are additive and do not modify any production code paths. The risk is limited to potential false positives or gaps in the new test assertions, which are unlikely to cause runtime issues.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->