### PR TITLE
Duplicate installation

### DIFF
--- a/api/src/__tests__/unit/services/github.service.test.ts
+++ b/api/src/__tests__/unit/services/github.service.test.ts
@@ -227,18 +227,57 @@ describe('GithubService (unit)', () => {
     expect(githubRepositoryRepository.deleteCascade).not.toHaveBeenCalled();
   });
 
-  it('syncs the workspace linked to an installation id', async () => {
-    workspaceRepository.findOne.mockResolvedValue({id: 42});
+  it('syncs every workspace linked to an installation id', async () => {
+    workspaceRepository.find.mockResolvedValue([{id: 42}, {id: 43}]);
     const syncWorkspaceInstallationSpy = vi
       .spyOn(internals, 'syncWorkspaceInstallation')
       .mockResolvedValue(undefined);
 
     await service.syncInstallationForConnectedWorkspace(77);
 
-    expect(workspaceRepository.findOne).toHaveBeenCalledWith({
+    expect(workspaceRepository.find).toHaveBeenCalledWith({
       where: {githubInstallationId: '77'},
     });
     expect(syncWorkspaceInstallationSpy).toHaveBeenCalledWith(42, 77);
+    expect(syncWorkspaceInstallationSpy).toHaveBeenCalledWith(43, 77);
+    expect(syncWorkspaceInstallationSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates incoming installation repositories before saving', async () => {
+    githubRepositoryRepository.find.mockResolvedValue([]);
+
+    await internals.saveInstallationRepositories(7, 99, [
+      {
+        id: 1001,
+        name: 'api',
+        full_name: 'team/api',
+        private: true,
+        html_url: 'https://github.com/team/api',
+      },
+      {
+        id: 1001,
+        name: 'api',
+        full_name: 'team/api',
+        private: true,
+        html_url: 'https://github.com/team/api',
+      },
+    ]);
+
+    expect(githubRepositoryRepository.create).toHaveBeenCalledTimes(1);
+    expect(githubRepositoryRepository.create).toHaveBeenCalledWith({
+      workspaceId: 7,
+      githubRepoId: 1001,
+      name: 'api',
+      fullName: 'team/api',
+    });
+    expect(auditEventService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          repositoryCount: 1,
+          incomingRepositoryIds: [1001],
+        },
+      }),
+    );
   });
 
   it('enqueues label sync alongside issue sync when syncing a workspace installation', async () => {

--- a/api/src/__tests__/unit/services/queue.service.test.ts
+++ b/api/src/__tests__/unit/services/queue.service.test.ts
@@ -127,12 +127,20 @@ describe('QueueService (unit)', () => {
       [
         SYNC_GITHUB_ISSUES_JOB_NAME,
         {installationId: 1, workspaceId: 2},
-        {delay: 10},
+        {
+          delay: 10,
+          jobId: `${SYNC_GITHUB_ISSUES_JOB_NAME}:2:1`,
+          removeOnComplete: true,
+        },
       ],
       [
         SYNC_GITHUB_LABELS_JOB_NAME,
         {installationId: 1, workspaceId: 2},
-        {delay: 11},
+        {
+          delay: 11,
+          jobId: `${SYNC_GITHUB_LABELS_JOB_NAME}:2:1`,
+          removeOnComplete: true,
+        },
       ],
       [
         CREATE_GITHUB_ISSUE_JOB_NAME,

--- a/api/src/services/github-integration/github.service.ts
+++ b/api/src/services/github-integration/github.service.ts
@@ -269,18 +269,20 @@ export class GithubService {
     installationId: number,
   ): Promise<void> {
     const workspaceRepository = await this.workspaceRepositoryGetter();
-    const workspace = await workspaceRepository.findOne({
+    const workspaces = await workspaceRepository.find({
       where: {githubInstallationId: installationId.toString()},
     });
 
-    if (!workspace) {
+    if (!workspaces.length) {
       console.warn('No workspace connected to GitHub installation', {
         installationId,
       });
       return;
     }
 
-    await this.syncWorkspaceInstallation(workspace.id, installationId);
+    for (const workspace of workspaces) {
+      await this.syncWorkspaceInstallation(workspace.id, installationId);
+    }
   }
 
   public async disconnectInstallation(installationId: number): Promise<void> {
@@ -498,11 +500,13 @@ export class GithubService {
         repository,
       ]),
     );
-    const incomingGithubRepoIds = new Set(
-      repositories.map(repository => repository.id),
+    const uniqueRepositoriesByGithubId = new Map(
+      repositories.map(repository => [repository.id, repository]),
     );
+    const uniqueRepositories = [...uniqueRepositoriesByGithubId.values()];
+    const incomingGithubRepoIds = new Set(uniqueRepositoriesByGithubId.keys());
 
-    for (const repository of repositories) {
+    for (const repository of uniqueRepositories) {
       const existingRepository = existingByGithubRepoId.get(repository.id);
 
       if (!existingRepository) {
@@ -541,7 +545,7 @@ export class GithubService {
       resourceId: String(installationId),
       source: 'github',
       payload: {
-        repositoryCount: repositories.length,
+        repositoryCount: uniqueRepositories.length,
         incomingRepositoryIds: [...incomingGithubRepoIds],
       },
     });

--- a/api/src/services/queue.service.ts
+++ b/api/src/services/queue.service.ts
@@ -86,19 +86,27 @@ export class QueueService {
 
   public async enqueueGithubIssuesSync(
     data: SyncGithubIssuesJobData,
-    options: Pick<JobsOptions, 'delay'> = {},
+    options: Pick<JobsOptions, 'delay' | 'jobId'> = {},
   ) {
     return this.getGithubIssuesQueue().add(SYNC_GITHUB_ISSUES_JOB_NAME, data, {
       delay: options.delay,
+      jobId:
+        options.jobId ??
+        buildWorkspaceInstallationJobId(SYNC_GITHUB_ISSUES_JOB_NAME, data),
+      removeOnComplete: true,
     });
   }
 
   public async enqueueGithubLabelsSync(
     data: SyncGithubIssuesJobData,
-    options: Pick<JobsOptions, 'delay'> = {},
+    options: Pick<JobsOptions, 'delay' | 'jobId'> = {},
   ) {
     return this.getGithubIssuesQueue().add(SYNC_GITHUB_LABELS_JOB_NAME, data, {
       delay: options.delay,
+      jobId:
+        options.jobId ??
+        buildWorkspaceInstallationJobId(SYNC_GITHUB_LABELS_JOB_NAME, data),
+      removeOnComplete: true,
     });
   }
 
@@ -158,4 +166,11 @@ export class QueueService {
 
 function shouldBypassQueueInTests(): boolean {
   return process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
+}
+
+function buildWorkspaceInstallationJobId(
+  jobName: string,
+  data: SyncGithubIssuesJobData,
+): string {
+  return `${jobName}:${data.workspaceId}:${data.installationId}`;
 }


### PR DESCRIPTION
## Summary

This PR fixes duplicate GitHub installation sync behavior.

GitHub installation sync now supports multiple workspaces connected to the same installation id, deduplicates incoming repository payloads before saving, and makes GitHub issue/label sync jobs idempotent with deterministic job IDs.

## What changed

- Updated installation sync to find all workspaces linked to a GitHub installation id.
- Syncs each connected workspace instead of only the first matching workspace.
- Keeps the existing no-op behavior when no workspace is connected to the installation.
- Deduplicates incoming installation repositories by GitHub repository id before saving.
- Prevents duplicate repository creation when GitHub sends repeated repository entries.
- Updates repository sync audit payloads to use deduplicated repository counts and IDs.
- Adds deterministic BullMQ job IDs for GitHub issue sync jobs.
- Adds deterministic BullMQ job IDs for GitHub label sync jobs.
- Enables `removeOnComplete` for issue/label sync jobs.
- Keeps optional custom job IDs supported through queue options.
- Updates GitHub service tests for multi-workspace installation sync.
- Adds GitHub service test coverage for repository payload deduplication.
- Updates queue service tests to assert deterministic issue/label sync job options.

## Why

The previous sync flow assumed a GitHub installation id mapped to only one workspace. That can break when multiple workspaces are connected to the same GitHub App installation.

This PR makes installation sync safer by processing every connected workspace, avoiding duplicate repository persistence, and preventing duplicate sync jobs for the same workspace/installation pair.

## Testing

Added or updated unit test coverage for:

- syncing every workspace linked to a GitHub installation id
- deduplicating incoming installation repositories before persistence
- avoiding duplicate repository creation
- audit payloads using deduplicated repository counts
- deterministic GitHub issue sync job IDs
- deterministic GitHub label sync job IDs
- `removeOnComplete` on issue/label sync jobs

<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Medium
> Reason: The PR modifies GitHub integration logic to handle multiple workspaces per installation and introduces deduplication of repositories. It also adds jobId and removeOnComplete options to queue jobs. The changes affect core integration behavior and job queuing but are well-tested. Risk is moderate due to the behavioral changes in syncing multiple workspaces.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->