### PR TITLE
Implement lazy loading via scroll indicator

### DIFF
--- a/api/src/__tests__/unit/controllers/issue.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/issue.controller.test.ts
@@ -93,10 +93,20 @@ describe('GithubIssueController (unit)', () => {
     issueRepository.find.mockResolvedValue([issue]);
 
     await expect(
-      controller.find({id: 7} as never, {where: {status: 'open'}}),
+      controller.find({id: 7} as never, {
+        include: ['aiPrediction'],
+        limit: 25,
+        skip: 50,
+        order: ['id DESC'],
+        where: {status: 'open'},
+      }),
     ).resolves.toEqual([issue]);
 
     expect(issueRepository.find).toHaveBeenCalledWith({
+      include: ['aiPrediction'],
+      limit: 25,
+      skip: 50,
+      order: ['id DESC'],
       where: {
         and: [{status: 'open'}, {repositoryId: {inq: [4]}}],
       },

--- a/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
+++ b/api/src/__tests__/unit/controllers/pull-request.controller.test.ts
@@ -59,10 +59,20 @@ describe('GithubPullRequestController (unit)', () => {
     pullRequestRepository.find.mockResolvedValue([pullRequest]);
 
     await expect(
-      controller.find({id: 7} as never, {where: {status: 'open'}}),
+      controller.find({id: 7} as never, {
+        include: ['aiPrediction'],
+        limit: 25,
+        skip: 50,
+        order: ['id DESC'],
+        where: {status: 'open'},
+      }),
     ).resolves.toEqual([pullRequest]);
 
     expect(pullRequestRepository.find).toHaveBeenCalledWith({
+      include: ['aiPrediction'],
+      limit: 25,
+      skip: 50,
+      order: ['id DESC'],
       where: {
         and: [{status: 'open'}, {repositoryId: {inq: [8]}}],
       },

--- a/client/app/components/routes/workspaces/edit/issues.gts
+++ b/client/app/components/routes/workspaces/edit/issues.gts
@@ -6,13 +6,17 @@ import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { task as trackedTask } from 'reactiveweb/ember-concurrency';
+import { modifier } from 'ember-modifier';
 import type { WorkspacesEditIssuesRouteModel } from 'client/routes/workspaces/edit/issues';
 import type GithubIssueModel from 'client/models/github-issue';
+import loadMoreWhenVisible from 'client/modifiers/load-more-when-visible';
+import mergeRecordsById from 'client/utils/merge-records-by-id';
 import UiIcon from 'client/components/ui/icon';
 import UiButton from 'client/components/ui/button';
 import UiContainer from 'client/components/ui/container';
 import UiLoadingSpinner from 'client/components/ui/loading-spinner';
+
+const ISSUE_PAGE_SIZE = 25;
 
 type RouterLike = {
   transitionTo(route: string): void;
@@ -43,30 +47,51 @@ export default class RoutesWorkspacesEditIssues extends Component<RoutesWorkspac
   @service declare router: RouterLike;
 
   @tracked activeFilters: string[] = [];
+  @tracked workspaceIssues: GithubIssueModel[] = [];
+  @tracked issueOffset = 0;
+  @tracked hasMoreIssues = true;
+  @tracked hasLoadedInitialIssues = false;
+  private paginationScopeKey: string | null = null;
 
-  fetchWorkspaceIssuesTask = task(async () => {
-    const repositoryIds = this.args.model.repositories.map((repo) => repo.id);
+  loadIssuesPageTask = task(async () => {
+    if (!this.hasMoreIssues) {
+      return;
+    }
+
+    const repositoryIds = this.repositoryIds;
+
+    if (!repositoryIds.length) {
+      this.hasMoreIssues = false;
+      this.hasLoadedInitialIssues = true;
+      return;
+    }
 
     const issues = await this.store.query('github-issue', {
       filter: {
         include: ['aiPrediction'],
+        limit: ISSUE_PAGE_SIZE,
+        skip: this.issueOffset,
+        order: ['id DESC'],
         where: {
           repositoryId: { inq: repositoryIds },
         },
       },
     });
 
-    return issues;
+    this.issueOffset += issues.length;
+    this.hasMoreIssues = issues.length === ISSUE_PAGE_SIZE;
+    this.hasLoadedInitialIssues = true;
+    this.workspaceIssues = mergeRecordsById(this.workspaceIssues, issues);
   });
 
-  lastWorkspaceIssues = trackedTask(
-    this,
-    this.fetchWorkspaceIssuesTask,
-    () => []
-  );
+  get repositoryIds(): Array<string | number> {
+    return this.args.model.repositories.flatMap((repo) =>
+      repo.id == null ? [] : [repo.id]
+    );
+  }
 
-  get workspaceIssues(): GithubIssueModel[] {
-    return (this.lastWorkspaceIssues.value as GithubIssueModel[]) ?? [];
+  get repositoryScopeKey(): string {
+    return this.repositoryIds.join(',');
   }
 
   get filters() {
@@ -154,6 +179,31 @@ export default class RoutesWorkspacesEditIssues extends Component<RoutesWorkspac
     return this.activeFilters.includes(selector);
   };
 
+  get canLoadMore(): boolean {
+    return this.hasMoreIssues && !this.loadIssuesPageTask.isRunning;
+  }
+
+  get showInitialLoading(): boolean {
+    return !this.hasLoadedInitialIssues && this.loadIssuesPageTask.isRunning;
+  }
+
+  get showNextPageLoading(): boolean {
+    return this.hasLoadedInitialIssues && this.loadIssuesPageTask.isRunning;
+  }
+
+  initializePagination = modifier((_element, [scopeKey]: [string]) => {
+    if (this.paginationScopeKey === scopeKey) {
+      return;
+    }
+
+    this.paginationScopeKey = scopeKey;
+
+    queueMicrotask(() => {
+      this.resetPagination();
+      this.loadNextPage();
+    });
+  });
+
   @action
   toggleFilter(selector: string): void {
     if (this.activeFilters.includes(selector)) {
@@ -171,9 +221,30 @@ export default class RoutesWorkspacesEditIssues extends Component<RoutesWorkspac
     this.router.transitionTo('workspaces.edit.issues.new');
   }
 
+  @action
+  loadNextPage(): void {
+    if (!this.canLoadMore) {
+      return;
+    }
+
+    this.loadIssuesPageTask.perform().catch((error: unknown) => {
+      console.error('Failed to load issues page', error);
+    });
+  }
+
+  private resetPagination(): void {
+    this.workspaceIssues = [];
+    this.issueOffset = 0;
+    this.hasMoreIssues = true;
+    this.hasLoadedInitialIssues = false;
+  }
+
   <template>
-    <div class="route-workspaces-edit-issues layout-vertical --gap-md">
-      {{#if this.lastWorkspaceIssues.isRunning}}
+    <div
+      class="route-workspaces-edit-issues layout-vertical --gap-md"
+      {{this.initializePagination this.repositoryScopeKey}}
+    >
+      {{#if this.showInitialLoading}}
         <UiLoadingSpinner @backdrop={{true}} />
       {{/if}}
 
@@ -277,6 +348,18 @@ export default class RoutesWorkspacesEditIssues extends Component<RoutesWorkspac
             </:default>
           </UiContainer>
         {{/unless}}
+
+        {{#if this.showNextPageLoading}}
+          <div class="issue-list-pagination-loader">
+            <UiLoadingSpinner />
+          </div>
+        {{/if}}
+
+        <div
+          class="issue-list-sentinel"
+          aria-hidden="true"
+          {{loadMoreWhenVisible this.loadNextPage enabled=this.canLoadMore}}
+        ></div>
       </div>
     </div>
   </template>

--- a/client/app/components/routes/workspaces/edit/pull-requests.gts
+++ b/client/app/components/routes/workspaces/edit/pull-requests.gts
@@ -6,15 +6,18 @@ import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { task as trackedTask } from 'reactiveweb/ember-concurrency';
+import { modifier } from 'ember-modifier';
 import type { WorkspacesEditPullRequestsRouteModel } from 'client/routes/workspaces/edit/pull-requests';
 import type GithubPullRequestModel from 'client/models/github-pull-request';
+import loadMoreWhenVisible from 'client/modifiers/load-more-when-visible';
+import mergeRecordsById from 'client/utils/merge-records-by-id';
 import UiIcon from 'client/components/ui/icon';
 import UiContainer from 'client/components/ui/container';
 import UiLoadingSpinner from 'client/components/ui/loading-spinner';
 
 const AI_PRIORITY_NOTE_START = '<!-- onlab-ai-priority:start -->';
 const AI_PRIORITY_NOTE_END = '<!-- onlab-ai-priority:end -->';
+const PULL_REQUEST_PAGE_SIZE = 25;
 
 type StoreLike = {
   query(
@@ -40,32 +43,54 @@ export default class RoutesWorkspacesEditPullRequests extends Component<RoutesWo
   @service declare store: StoreLike;
 
   @tracked activeFilters: string[] = [];
+  @tracked workspacePullRequests: GithubPullRequestModel[] = [];
+  @tracked pullRequestOffset = 0;
+  @tracked hasMorePullRequests = true;
+  @tracked hasLoadedInitialPullRequests = false;
+  private paginationScopeKey: string | null = null;
 
-  fetchWorkspacePullRequestsTask = task(async () => {
-    const repositoryIds = this.args.model.repositories.map((repo) => repo.id);
+  loadPullRequestsPageTask = task(async () => {
+    if (!this.hasMorePullRequests) {
+      return;
+    }
 
-    const pullRequests = this.store.query('github-pull-request', {
+    const repositoryIds = this.repositoryIds;
+
+    if (!repositoryIds.length) {
+      this.hasMorePullRequests = false;
+      this.hasLoadedInitialPullRequests = true;
+      return;
+    }
+
+    const pullRequests = await this.store.query('github-pull-request', {
       filter: {
         include: ['aiPrediction'],
+        limit: PULL_REQUEST_PAGE_SIZE,
+        skip: this.pullRequestOffset,
+        order: ['id DESC'],
         where: {
           repositoryId: { inq: repositoryIds },
         },
       },
     });
 
-    return pullRequests;
+    this.pullRequestOffset += pullRequests.length;
+    this.hasMorePullRequests = pullRequests.length === PULL_REQUEST_PAGE_SIZE;
+    this.hasLoadedInitialPullRequests = true;
+    this.workspacePullRequests = mergeRecordsById(
+      this.workspacePullRequests,
+      pullRequests
+    );
   });
 
-  lastWorkspacePullRequests = trackedTask(
-    this,
-    this.fetchWorkspacePullRequestsTask,
-    () => []
-  );
-
-  get workspacePullRequests(): GithubPullRequestModel[] {
-    return (
-      (this.lastWorkspacePullRequests.value as GithubPullRequestModel[]) ?? []
+  get repositoryIds(): Array<string | number> {
+    return this.args.model.repositories.flatMap((repo) =>
+      repo.id == null ? [] : [repo.id]
     );
+  }
+
+  get repositoryScopeKey(): string {
+    return this.repositoryIds.join(',');
   }
 
   get filters() {
@@ -234,6 +259,37 @@ export default class RoutesWorkspacesEditPullRequests extends Component<RoutesWo
     return this.activeFilters.includes(selector);
   };
 
+  get canLoadMore(): boolean {
+    return this.hasMorePullRequests && !this.loadPullRequestsPageTask.isRunning;
+  }
+
+  get showInitialLoading(): boolean {
+    return (
+      !this.hasLoadedInitialPullRequests &&
+      this.loadPullRequestsPageTask.isRunning
+    );
+  }
+
+  get showNextPageLoading(): boolean {
+    return (
+      this.hasLoadedInitialPullRequests &&
+      this.loadPullRequestsPageTask.isRunning
+    );
+  }
+
+  initializePagination = modifier((_element, [scopeKey]: [string]) => {
+    if (this.paginationScopeKey === scopeKey) {
+      return;
+    }
+
+    this.paginationScopeKey = scopeKey;
+
+    queueMicrotask(() => {
+      this.resetPagination();
+      this.loadNextPage();
+    });
+  });
+
   @action
   toggleFilter(selector: string): void {
     if (this.activeFilters.includes(selector)) {
@@ -246,9 +302,30 @@ export default class RoutesWorkspacesEditPullRequests extends Component<RoutesWo
     this.activeFilters = [...this.activeFilters, selector];
   }
 
+  @action
+  loadNextPage(): void {
+    if (!this.canLoadMore) {
+      return;
+    }
+
+    this.loadPullRequestsPageTask.perform().catch((error: unknown) => {
+      console.error('Failed to load pull requests page', error);
+    });
+  }
+
+  private resetPagination(): void {
+    this.workspacePullRequests = [];
+    this.pullRequestOffset = 0;
+    this.hasMorePullRequests = true;
+    this.hasLoadedInitialPullRequests = false;
+  }
+
   <template>
-    <div class="route-workspaces-edit-pull-requests layout-vertical --gap-md">
-      {{#if this.lastWorkspacePullRequests.isRunning}}
+    <div
+      class="route-workspaces-edit-pull-requests layout-vertical --gap-md"
+      {{this.initializePagination this.repositoryScopeKey}}
+    >
+      {{#if this.showInitialLoading}}
         <UiLoadingSpinner @backdrop={{true}} />
       {{/if}}
 
@@ -406,6 +483,18 @@ export default class RoutesWorkspacesEditPullRequests extends Component<RoutesWo
             </:default>
           </UiContainer>
         {{/unless}}
+
+        {{#if this.showNextPageLoading}}
+          <div class="pull-request-list-pagination-loader">
+            <UiLoadingSpinner />
+          </div>
+        {{/if}}
+
+        <div
+          class="pull-request-list-sentinel"
+          aria-hidden="true"
+          {{loadMoreWhenVisible this.loadNextPage enabled=this.canLoadMore}}
+        ></div>
       </div>
     </div>
   </template>

--- a/client/app/modifiers/load-more-when-visible.ts
+++ b/client/app/modifiers/load-more-when-visible.ts
@@ -1,0 +1,41 @@
+import { modifier } from 'ember-modifier';
+
+type LoadMoreWhenVisibleNamedArgs = {
+  enabled?: boolean;
+  rootMargin?: string;
+};
+
+export default modifier(
+  (
+    element: Element,
+    [onLoadMore]: [() => void],
+    {
+      enabled = true,
+      rootMargin = '0px 0px 18rem 0px',
+    }: LoadMoreWhenVisibleNamedArgs
+  ) => {
+    if (!enabled || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) {
+          return;
+        }
+
+        queueMicrotask(onLoadMore);
+      },
+      {
+        root: element.parentElement,
+        rootMargin,
+      }
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }
+);

--- a/client/app/styles/routes/workspaces/issues.css
+++ b/client/app/styles/routes/workspaces/issues.css
@@ -152,6 +152,16 @@
     .issue-card .ui-container__header {
       padding-bottom: 0;
     }
+
+    .issue-list-pagination-loader {
+      display: grid;
+      place-items: center;
+      padding: var(--space-md);
+    }
+
+    .issue-list-sentinel {
+      min-height: 1px;
+    }
   }
 }
 

--- a/client/app/styles/routes/workspaces/pull-requests.css
+++ b/client/app/styles/routes/workspaces/pull-requests.css
@@ -223,6 +223,16 @@
   .pull-request-empty-state {
     text-align: left;
   }
+
+  .pull-request-list-pagination-loader {
+    display: grid;
+    place-items: center;
+    padding: var(--space-md);
+  }
+
+  .pull-request-list-sentinel {
+    min-height: 1px;
+  }
 }
 
 .route-workspaces-edit-pull-requests-edit {

--- a/client/app/utils/merge-records-by-id.ts
+++ b/client/app/utils/merge-records-by-id.ts
@@ -1,0 +1,15 @@
+export default function mergeRecordsById<
+  RecordType extends { id: string | null },
+>(existingRecords: RecordType[], nextRecords: RecordType[]): RecordType[] {
+  const recordsById = new Map<string, RecordType>();
+
+  for (const record of [...existingRecords, ...nextRecords]) {
+    if (!record.id) {
+      continue;
+    }
+
+    recordsById.set(record.id, record);
+  }
+
+  return [...recordsById.values()];
+}


### PR DESCRIPTION
<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Medium
> Reason: The PR introduces lazy loading functionality via scroll indicators in the client components for issues and pull requests. It adds new modifiers and utility functions, and modifies existing components to support pagination. The changes are moderately complex but appear to be well-scoped. The main risk comes from the new IntersectionObserver-based modifier logic which could lead to performance issues or incorrect loading behavior if not properly managed. However, the test files show that the API controllers are correctly passing through the new query parameters (limit, skip, order), suggesting proper backend integration.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->