### PR TITLE
Remove inject imports due to deprecation

### DIFF
--- a/client/app/components/flash-messages.gts
+++ b/client/app/components/flash-messages.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import UiAlert from 'client/components/ui/alert';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import type { EmptyArgs } from 'client/types/component';
 

--- a/client/app/components/route-profile.gts
+++ b/client/app/components/route-profile.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import UiAvatar from 'client/components/ui/avatar';
 import { LinkTo } from '@ember/routing';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from '@ember/helper';
 import { or } from 'ember-truth-helpers';
 import type UserModel from 'client/models/user';

--- a/client/app/components/routes/profile.gts
+++ b/client/app/components/routes/profile.gts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import UiIcon from 'client/components/ui/icon';
 import UiThemeSwitcher from 'client/components/ui/theme-switcher';

--- a/client/app/components/routes/workspaces/edit/capacity-planning/editor.gts
+++ b/client/app/components/routes/workspaces/edit/capacity-planning/editor.gts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import { task } from 'ember-concurrency';
 import UiAvatar from 'client/components/ui/avatar';

--- a/client/app/components/routes/workspaces/edit/issues.gts
+++ b/client/app/components/routes/workspaces/edit/issues.gts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 import type { WorkspacesEditIssuesRouteModel } from 'client/routes/workspaces/edit/issues';

--- a/client/app/components/routes/workspaces/edit/issues/new.gts
+++ b/client/app/components/routes/workspaces/edit/issues/new.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { LinkTo } from '@ember/routing';
 import { on } from '@ember/modifier';

--- a/client/app/components/routes/workspaces/edit/pull-requests.gts
+++ b/client/app/components/routes/workspaces/edit/pull-requests.gts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 import type { WorkspacesEditPullRequestsRouteModel } from 'client/routes/workspaces/edit/pull-requests';

--- a/client/app/components/routes/workspaces/edit/settings.gts
+++ b/client/app/components/routes/workspaces/edit/settings.gts
@@ -3,7 +3,7 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { eq, not, or } from 'ember-truth-helpers';
 import UiAlert from 'client/components/ui/alert';
 import UiAriaTabs from 'client/components/ui/aria-tabs';

--- a/client/app/components/routes/workspaces/index.gts
+++ b/client/app/components/routes/workspaces/index.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import UiIcon from 'client/components/ui/icon';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import UiLoadingSpinner from 'client/components/ui/loading-spinner';
 import type InvitationModel from 'client/models/invitation';

--- a/client/app/components/routes/workspaces/index/invitation-card.gts
+++ b/client/app/components/routes/workspaces/index/invitation-card.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import UiAvatar from 'client/components/ui/avatar';
 import UiButton from 'client/components/ui/button';

--- a/client/app/components/routes/workspaces/new.gts
+++ b/client/app/components/routes/workspaces/new.gts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import UiButton from 'client/components/ui/button';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import UiForm from 'client/components/ui/form';
 import UiFormGroup from 'client/components/ui/form-group';
 import UiInput from 'client/components/ui/input';

--- a/client/app/components/ui/avatar.gts
+++ b/client/app/components/ui/avatar.gts
@@ -6,7 +6,7 @@ import { guidFor } from '@ember/object/internals';
 import { on } from '@ember/modifier';
 import { modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import UiLoadingSpinner from 'client/components/ui/loading-spinner';
 import { eq } from 'ember-truth-helpers';
 

--- a/client/app/components/ui/language-selector.gts
+++ b/client/app/components/ui/language-selector.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import UiDropdown from 'client/components/ui/dropdown';
 import { t } from 'ember-intl';

--- a/client/app/routes/application.ts
+++ b/client/app/routes/application.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import type Transition from '@ember/routing/transition';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import IntlService from 'ember-intl/services/intl';
 import moment from 'moment';

--- a/client/app/routes/protected.ts
+++ b/client/app/routes/protected.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import type ApiService from 'client/services/api';
 

--- a/client/app/routes/workspaces/edit.ts
+++ b/client/app/routes/workspaces/edit.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type WorkspaceModel from 'client/models/workspace';
 import type GithubRepositoryModel from 'client/models/github-repository';
 import ProtectedRoute from 'client/routes/protected';

--- a/client/app/routes/workspaces/edit/capacity-planning.ts
+++ b/client/app/routes/workspaces/edit/capacity-planning.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type CapacityPlanEntryModel from 'client/models/capacity-plan-entry';
 import type CapacityPlanModel from 'client/models/capacity-plan';
 import type GithubIssueModel from 'client/models/github-issue';

--- a/client/app/routes/workspaces/edit/communication.ts
+++ b/client/app/routes/workspaces/edit/communication.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type WorkspaceModel from 'client/models/workspace';
 import type WorkspaceMemberModel from 'client/models/workspace-member';
 import type UserModel from 'client/models/user';

--- a/client/app/routes/workspaces/edit/issues/edit.ts
+++ b/client/app/routes/workspaces/edit/issues/edit.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type GithubIssueModel from 'client/models/github-issue';
 import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesEditIssuesRouteModel } from 'client/routes/workspaces/edit/issues';

--- a/client/app/routes/workspaces/edit/news-feed.ts
+++ b/client/app/routes/workspaces/edit/news-feed.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type GithubRepositoryModel from 'client/models/github-repository';
 import type NewsFeedEntryModel from 'client/models/news-feed-entry';
 import type WorkspaceModel from 'client/models/workspace';

--- a/client/app/routes/workspaces/edit/news-feed/capacity-plan.ts
+++ b/client/app/routes/workspaces/edit/news-feed/capacity-plan.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type CapacityPlanEntryModel from 'client/models/capacity-plan-entry';
 import type CapacityPlanModel from 'client/models/capacity-plan';
 import type IssueAssignmentModel from 'client/models/issue-assignment';

--- a/client/app/routes/workspaces/edit/news-feed/issue.ts
+++ b/client/app/routes/workspaces/edit/news-feed/issue.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type GithubIssueModel from 'client/models/github-issue';
 import type { WorkspacesEditNewsFeedRouteModel } from 'client/routes/workspaces/edit/news-feed';
 

--- a/client/app/routes/workspaces/edit/news-feed/pull-request.ts
+++ b/client/app/routes/workspaces/edit/news-feed/pull-request.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type GithubPullRequestModel from 'client/models/github-pull-request';
 import type { WorkspacesEditNewsFeedRouteModel } from 'client/routes/workspaces/edit/news-feed';
 

--- a/client/app/routes/workspaces/edit/pull-requests/edit.ts
+++ b/client/app/routes/workspaces/edit/pull-requests/edit.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type GithubPullRequestModel from 'client/models/github-pull-request';
 import ProtectedRoute from 'client/routes/protected';
 import type { WorkspacesEditPullRequestsRouteModel } from 'client/routes/workspaces/edit/pull-requests';

--- a/client/app/routes/workspaces/index.ts
+++ b/client/app/routes/workspaces/index.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import type WorkspaceModel from 'client/models/workspace';
 

--- a/client/app/routes/workspaces/new.ts
+++ b/client/app/routes/workspaces/new.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type WorkspaceModel from 'client/models/workspace';
 import type SessionAccountService from 'client/services/session-account';
 

--- a/client/app/services/last-workspace.ts
+++ b/client/app/services/last-workspace.ts
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 type SessionAccountServiceLike = {
   id?: number;

--- a/client/app/services/session-account.ts
+++ b/client/app/services/session-account.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type UserModel from 'client/models/user';
 
 type SessionData = {


### PR DESCRIPTION
<!-- onlab-ai-priority:start -->
> [!NOTE]
> AI merge risk prediction: Low
> Reason: This PR updates import statements to use the new `service` import from `@ember/service` instead of the deprecated `inject as service`. This is a mechanical change with low risk as it only affects import aliases and does not alter functionality. The changes are consistent across all modified files.

> Written by `DevTeams`
<!-- onlab-ai-priority:end -->